### PR TITLE
Windows 10.586 NtCreateThdIndex

### DIFF
--- a/src/BlackBoneDrv/BlackBoneDrv.c
+++ b/src/BlackBoneDrv/BlackBoneDrv.c
@@ -297,7 +297,7 @@ NTSTATUS BBInitDynamicData( IN OUT PDYNAMIC_DATA pData )
                 pData->Protection       = 0x6AA;
                 pData->ObjTable         = 0x418;
                 pData->VadRoot          = 0x608;
-                pData->NtCreateThdIndex = 0xB3;
+                pData->NtCreateThdIndex = 0xB4;
                 pData->NtTermThdIndex   = 0x53;
                 pData->PrevMode         = 0x232;
                 pData->ExitStatus       = 0x6E0;


### PR DESCRIPTION
I came here for some easy offsets for Win10.  Turned out they were wrong.  But no worries, it looks like only NtCreateThdIndex shifted by a byte from 0xB3 -> 0xB4.