### PR TITLE
Add ability to pass data using lpReserved

### DIFF
--- a/src/BlackBone/ManualMap/MMap.cpp
+++ b/src/BlackBone/ManualMap/MMap.cpp
@@ -993,9 +993,9 @@ bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason, CustomAr
     intptr_t customArgumentsAddress = 0;
     if (pCustomArgs)
     {
-        auto memBuf = _process.memory().Allocate( pCustomArgs->size() + sizeof( size_t ), PAGE_EXECUTE_READWRITE, 0, false );
+        auto memBuf = _process.memory().Allocate( pCustomArgs->size() + sizeof( uint64_t ), PAGE_EXECUTE_READWRITE, 0, false );
         memBuf.Write( 0, pCustomArgs->size() );
-        memBuf.Write( sizeof(uint64_t), pCustomArgs->size(), pCustomArgs->data() );
+        memBuf.Write( sizeof( uint64_t ), pCustomArgs->size(), pCustomArgs->data() );
         customArgumentsAddress = static_cast<intptr_t>( memBuf.ptr() );
     }
 

--- a/src/BlackBone/ManualMap/MMap.cpp
+++ b/src/BlackBone/ManualMap/MMap.cpp
@@ -35,10 +35,11 @@ const ModuleData* MMap::MapImage(
     const std::wstring& path,
     eLoadFlags flags /*= NoFlags*/,
     MapCallback mapCallback /*= nullptr*/,
-    void* context /*= nullptr*/
+    void* context /*= nullptr*/,
+    CustomArgs_t* pCustomArgs /*= nullptr*/
     )
 {
-    return MapImageInternal( path, nullptr, 0, false, flags, mapCallback, context );
+    return MapImageInternal( path, nullptr, 0, false, flags, mapCallback, context, pCustomArgs );
 }
 
 /// <summary>
@@ -56,14 +57,15 @@ const ModuleData* MMap::MapImage(
     bool asImage /*= false*/,
     eLoadFlags flags /*= NoFlags*/,
     MapCallback mapCallback /*= nullptr*/,
-    void* context /*= nullptr*/
+    void* context /*= nullptr*/,
+    CustomArgs_t* pCustomArgs /*= nullptr*/
     )
 {
     // Create fake path
     wchar_t path[64];
     wsprintfW( path, L"MemoryImage_0x%p", buffer );
 
-    return MapImageInternal( path, buffer, size, asImage, flags, mapCallback, context );
+    return MapImageInternal( path, buffer, size, asImage, flags, mapCallback, context, pCustomArgs );
 }
 
 /// <summary>
@@ -83,7 +85,8 @@ const ModuleData* MMap::MapImageInternal(
     bool asImage /*= false*/,
     eLoadFlags flags /*= NoFlags*/,
     MapCallback mapCallback /*= nullptr*/,
-    void* context /*= nullptr*/
+    void* context /*= nullptr*/,
+    CustomArgs_t* pCustomArgs /*= nullptr*/
     )
 {
     // Already loaded
@@ -166,7 +169,7 @@ const ModuleData* MMap::MapImageInternal(
                 img->imgMem.Protect( flOld, img->peImage.ilFlagOffset(), sizeof( flg ), &flOld );
             }
 
-            if (!RunModuleInitializers( img.get(), DLL_PROCESS_ATTACH ))
+            if (!RunModuleInitializers( img.get(), DLL_PROCESS_ATTACH, pCustomArgs ))
                 return nullptr;
 
             // Wipe header
@@ -967,7 +970,7 @@ bool MMap::InitializeCookie( ImageContext* pImage )
 /// DLL_THREAD_DETTACH
 /// </param>
 /// <returns>true on success</returns>
-bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason )
+bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason, CustomArgs_t* pCustomArgs /*= nullptr*/ )
 {
     AsmJitHelper a;
     uint64_t result = 0;
@@ -983,7 +986,17 @@ bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason )
     {
         a->mov( a->zax, _pAContext.ptr<size_t>() );
         a->mov( a->zax, asmjit::host::dword_ptr( a->zax ) );
-        a.GenCall( static_cast<size_t>(pActivateActx.procAddress), { 0, a->zax, _pAContext.ptr<size_t>() + sizeof( HANDLE ) } );
+        a.GenCall( static_cast<size_t>( pActivateActx.procAddress ), { 0, a->zax, _pAContext.ptr<size_t>() + sizeof( HANDLE ) } );
+    }
+
+    // Prepare custom arguments
+    intptr_t customArgumentsAddress = 0;
+    if (pCustomArgs)
+    {
+        auto memBuf = _process.memory().Allocate( pCustomArgs->size() + sizeof( size_t ), PAGE_EXECUTE_READWRITE, 0, false );
+        memBuf.Write( 0, pCustomArgs->size() );
+        memBuf.Write( sizeof(uint64_t), pCustomArgs->size(), pCustomArgs->data() );
+        customArgumentsAddress = static_cast<intptr_t>( memBuf.ptr() );
     }
 
     // Function order
@@ -991,20 +1004,20 @@ bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason )
     if (dwReason == DLL_PROCESS_ATTACH || dwReason == DLL_THREAD_ATTACH)
     {
         // PTLS_CALLBACK_FUNCTION(pImage->ImageBase, dwReason, NULL);
-        if (!(pImage->flags & NoTLS))
+        if (!( pImage->flags & NoTLS ))
             for (auto& pCallback : pImage->tlsCallbacks)
             {
-                BLACBONE_TRACE( L"ManualMap: Calling TLS callback at 0x%p for '%ls', Reason: %d", 
-                                static_cast<size_t>(pCallback), pImage->FileName.c_str(), dwReason );
+                BLACBONE_TRACE( L"ManualMap: Calling TLS callback at 0x%p for '%ls', Reason: %d",
+                    static_cast<size_t>( pCallback ), pImage->FileName.c_str(), dwReason );
 
-                a.GenCall( static_cast<size_t>(pCallback), { pImage->imgMem.ptr<size_t>(), dwReason, NULL } );
+                a.GenCall( static_cast<size_t>( pCallback ), { pImage->imgMem.ptr<size_t>(), dwReason, customArgumentsAddress } );
             }
 
         // DllMain
         if (pImage->EntryPoint != 0)
         {
             BLACBONE_TRACE( L"ManualMap: Calling entry point for '%ls', Reason: %d", pImage->FileName.c_str(), dwReason );
-            a.GenCall( static_cast<size_t>(pImage->EntryPoint), { pImage->imgMem.ptr<size_t>(), dwReason, NULL } );
+            a.GenCall( static_cast<size_t>( pImage->EntryPoint ), { pImage->imgMem.ptr<size_t>(), dwReason, customArgumentsAddress } );
         }
     }
     // Entry point first, TLS last
@@ -1014,26 +1027,26 @@ bool MMap::RunModuleInitializers( ImageContext* pImage, DWORD dwReason )
         if (pImage->EntryPoint != 0)
         {
             BLACBONE_TRACE( L"ManualMap: Calling entry point for '%ls', Reason: %d", pImage->FileName.c_str(), dwReason );
-            a.GenCall( static_cast<size_t>(pImage->EntryPoint), { pImage->imgMem.ptr<size_t>(), dwReason, NULL } );
+            a.GenCall( static_cast<size_t>( pImage->EntryPoint ), { pImage->imgMem.ptr<size_t>(), dwReason, customArgumentsAddress } );
         }
 
         // PTLS_CALLBACK_FUNCTION(pImage->ImageBase, dwReason, NULL);
-        if (!(pImage->flags & NoTLS))
+        if (!( pImage->flags & NoTLS ))
             for (auto& pCallback : pImage->tlsCallbacks)
             {
-                BLACBONE_TRACE( L"ManualMap: Calling TLS callback at 0x%p for '%ls', Reason: %d", 
-                                static_cast<size_t>(pCallback), pImage->FileName.c_str(), dwReason );
+                BLACBONE_TRACE( L"ManualMap: Calling TLS callback at 0x%p for '%ls', Reason: %d",
+                    static_cast<size_t>( pCallback ), pImage->FileName.c_str(), dwReason );
 
-                a.GenCall( static_cast<size_t>(pCallback), { pImage->imgMem.ptr<size_t>(), dwReason, NULL } );
+                a.GenCall( static_cast<size_t>( pCallback ), { pImage->imgMem.ptr<size_t>(), dwReason, customArgumentsAddress } );
             }
     }
 
     // DeactivateActCtx
     if (_pAContext.valid() && pDeactivateeActx.procAddress)
     {
-        a->mov( a->zax, _pAContext.ptr<size_t>() + sizeof(HANDLE) );
+        a->mov( a->zax, _pAContext.ptr<size_t>() + sizeof( HANDLE ) );
         a->mov( a->zax, asmjit::host::dword_ptr( a->zax ) );
-        a.GenCall( static_cast<size_t>(pDeactivateeActx.procAddress), { 0, a->zax } );
+        a.GenCall( static_cast<size_t>( pDeactivateeActx.procAddress ), { 0, a->zax } );
     }
 
     _process.remote().AddReturnWithEvent( a, pImage->peImage.mType() );

--- a/src/BlackBone/ManualMap/MMap.h
+++ b/src/BlackBone/ManualMap/MMap.h
@@ -8,11 +8,99 @@
 #include "../Process/MemBlock.h"
 #include "MExcept.h"
 
+#include <array>
+#include <vector>
 #include <map>
 #include <stack>
 
 namespace blackbone
 {
+
+class CustomArgs_t {
+private:
+    /// <summary>The buffer.</summary>
+    std::vector< char > _buffer;
+
+    /// <summary>Buffers.</summary>
+    /// <param name="ptr">[in] If non-null, the pointer.</param>
+    /// <param name="size">The size.</param>
+    void buffer( const void* ptr, size_t size )
+    {
+        if( !ptr )
+        {
+            return;
+        }
+        _buffer.resize( size );
+        memcpy( _buffer.data(), ptr, size );
+    }
+
+public:
+    /// <summary>Default constructor - Deleted</summary>
+    CustomArgs_t() = delete;
+
+    /// <summary>Constructor.</summary>
+    /// <param name="ptr">The pointer.</param>
+    /// <param name="size">The size.</param>
+    CustomArgs_t( const void* ptr, size_t size )
+    {
+        buffer( ptr, size );
+    }
+
+    /// <summary>Constructor.</summary>
+    /// <typeparam name="Arg_t">Type of the argument.</typeparam>
+    /// <param name="str">The string.</param>
+    template< typename Arg_t >
+    explicit CustomArgs_t( const std::basic_string< Arg_t >& str )
+    {
+        buffer( str.data(), str.size() * sizeof Arg_t );
+    }
+
+    /// <summary>Constructor.</summary>
+    /// <typeparam name="Arg_t">Type of the argument.</typeparam>
+    /// <param name="ptr">[in,out] If non-null, the pointer.</param>
+    template< class Arg_t >
+    explicit CustomArgs_t( Arg_t* ptr )
+    {
+        buffer( ptr, sizeof Arg_t );
+    }
+
+    /// <summary>Constructor.</summary>
+    /// <typeparam name="Arg_t">Type of the argument.</typeparam>
+    /// <param name="cVec">The vector.</param>
+    template< class Arg_t >
+    explicit CustomArgs_t( const std::vector< Arg_t >& cVec )
+    {
+        buffer( cVec.data(), cVec.size() * sizeof Arg_t );
+    }
+
+    /// <summary>Constructor.</summary>
+    /// <typeparam name="Arg_t">Type of the argument.</typeparam>
+    /// <typeparam name="N">Type of the n.</typeparam>
+    /// <param name="cArray">The array.</param>
+    template< class Arg_t, size_t N >
+    explicit CustomArgs_t( const std::array< Arg_t, N >& cArray )
+    {
+        buffer( cArray.data(), cArray.size() * sizeof Arg_t );
+    }
+
+    /// <summary>Gets the size.</summary>
+    /// <returns>An size_t.</returns>
+    size_t size() const {
+        return _buffer.size();
+    }
+
+    /// <summary>Gets the data.</summary>
+    /// <returns>null if it fails, else a char*.</returns>
+    char* data() {
+        return _buffer.data();
+    }
+
+    /// <summary>Gets the data.</summary>
+    /// <returns>null if it fails, else a char*.</returns>
+    const char* data() const {
+        return _buffer.data();
+    }
+};
 
 // Loader flags
 enum eLoadFlags
@@ -107,7 +195,8 @@ public:
         const std::wstring& path,
         eLoadFlags flags = NoFlags,
         MapCallback mapCallback = nullptr,
-        void* context = nullptr
+        void* context = nullptr,
+        CustomArgs_t* pCustomArgs_t = nullptr
         );
 
     /// <summary>
@@ -125,7 +214,8 @@ public:
         bool asImage = false,
         eLoadFlags flags = NoFlags,
         MapCallback mapCallback = nullptr,
-        void* context = nullptr
+        void* context = nullptr,
+        CustomArgs_t* pCustomArgs_t = nullptr
         );
 
     /// <summary>
@@ -163,7 +253,8 @@ private:
         bool asImage = false,
         eLoadFlags flags = NoFlags,
         MapCallback ldrCallback = nullptr,
-        void* ldrContext = nullptr
+        void* ldrContext = nullptr,
+        CustomArgs_t* pCustomArgs_t = nullptr
         );
  
     /// <summary>
@@ -196,7 +287,7 @@ private:
     /// DLL_THREAD_DETTACH
     /// </param>
     /// <returns>true on success</returns>
-    bool RunModuleInitializers( ImageContext* pImage, DWORD dwReason );
+    bool RunModuleInitializers( ImageContext* pImage, DWORD dwReason, CustomArgs_t* pCustomArgs_t = nullptr );
 
     /// <summary>
     /// Copies image into target process

--- a/src/BlackBone/Process/MemBlock.cpp
+++ b/src/BlackBone/Process/MemBlock.cpp
@@ -18,7 +18,7 @@ MemBlock::MemBlock()
 /// <param name="ptr">Memory address</param>
 /// <param name="size">Block size</param>
 /// <param name="prot">Memory protection</param>
-/// <param name="own">true if caller will be responsible for block deallocation</param>
+/// <param name="own">false if caller will be responsible for block deallocation</param>
 MemBlock::MemBlock( ProcessMemory* mem, ptr_t ptr, size_t size, DWORD prot, bool own /*= true*/, bool physical /*= false*/ )
     : _ptr( ptr )
     , _size( size )
@@ -60,8 +60,9 @@ MemBlock::~MemBlock()
 /// <param name="size">Block size</param>
 /// <param name="desired">Desired base address of new block</param>
 /// <param name="protection">Memory protection</param>
+/// <param name="own">false if caller will be responsible for block deallocation</param>
 /// <returns>Memory block. If failed - returned block will be invalid</returns>
-MemBlock MemBlock::Allocate( ProcessMemory& process, size_t size, ptr_t desired /*= 0*/, DWORD protection /*= PAGE_EXECUTE_READWRITE */ )
+MemBlock MemBlock::Allocate( ProcessMemory& process, size_t size, ptr_t desired /*= 0*/, DWORD protection /*= PAGE_EXECUTE_READWRITE */, bool own /*= true*/ )
 {
     ptr_t desired64 = desired;
     DWORD newProt = CastProtection( protection, process.core().DEP() );
@@ -75,7 +76,7 @@ MemBlock MemBlock::Allocate( ProcessMemory& process, size_t size, ptr_t desired 
             desired64 = 0;
     }
 
-    return MemBlock( &process, desired64, size, protection );
+    return MemBlock( &process, desired64, size, protection, own );
 }
 
 /// <summary>

--- a/src/BlackBone/Process/MemBlock.h
+++ b/src/BlackBone/Process/MemBlock.h
@@ -76,12 +76,14 @@ public:
     /// <param name="size">Block size</param>
     /// <param name="desired">Desired base address of new block</param>
     /// <param name="protection">Win32 Memory protection flags</param>
+    /// <param name="own">false if caller will be responsible for block deallocation</param>
     /// <returns>Memory block. If failed - returned block will be invalid</returns>
     BLACKBONE_API static MemBlock Allocate(
-        class ProcessMemory& process,
+    class ProcessMemory& process,
         size_t size,
-        ptr_t desired = 0, 
-        DWORD protection = PAGE_EXECUTE_READWRITE 
+        ptr_t desired = 0,
+        DWORD protection = PAGE_EXECUTE_READWRITE,
+        bool own = true
         );
 
     /// <summary>

--- a/src/BlackBone/Process/ProcessMemory.cpp
+++ b/src/BlackBone/Process/ProcessMemory.cpp
@@ -21,10 +21,11 @@ ProcessMemory::~ProcessMemory()
 /// <param name="size">Block size</param>
 /// <param name="protection">Memory protection</param>
 /// <param name="desired">Desired base address of new block</param>
+/// <param name="own">false if caller will be responsible for block deallocation</param>
 /// <returns>Memory block. If failed - returned block will be invalid</returns>
-MemBlock ProcessMemory::Allocate( size_t size, DWORD protection /*= PAGE_EXECUTE_READWRITE*/, ptr_t desired /*= 0*/ )
+MemBlock ProcessMemory::Allocate( size_t size, DWORD protection /*= PAGE_EXECUTE_READWRITE*/, ptr_t desired /*= 0*/, bool own /*= true*/ )
 {
-    return MemBlock::Allocate( *this, size, desired, protection );
+    return MemBlock::Allocate( *this, size, desired, protection, own );
 }
 
 /// <summary>

--- a/src/BlackBone/Process/ProcessMemory.h
+++ b/src/BlackBone/Process/ProcessMemory.h
@@ -22,8 +22,9 @@ public:
     /// <param name="size">Block size</param>
     /// <param name="protection">Memory protection</param>
     /// <param name="desired">Desired base address of new block</param>
+    /// <param name="desired">false if caller will be responsible for block deallocation</param>
     /// <returns>Memory block. If failed - returned block will be invalid</returns>
-    BLACKBONE_API MemBlock Allocate( size_t size, DWORD protection = PAGE_EXECUTE_READWRITE, ptr_t desired = 0 );
+    BLACKBONE_API MemBlock Allocate( size_t size, DWORD protection = PAGE_EXECUTE_READWRITE, ptr_t desired = 0, bool own = true );
 
     /// <summary>
     /// Free memory


### PR DESCRIPTION
I changed the description of the parameter `own` in the constructor of `MemBlock`. Please revert the change if I'm too dumb to understand, but as far as I understood the code it's the other way around.

The injected dll will get passed an address pointing to the `std::uint64_t` representing the size of the data immediately following it.