### PR TITLE
Update offsets for W10 14393

### DIFF
--- a/src/BlackBoneDrv/BlackBoneDrv.c
+++ b/src/BlackBoneDrv/BlackBoneDrv.c
@@ -226,7 +226,6 @@ NTSTATUS BBGetBuildNO( OUT PULONG pBuildNo )
 NTSTATUS BBInitDynamicData( IN OUT PDYNAMIC_DATA pData )
 {
     NTSTATUS status = STATUS_SUCCESS;
-    const ULONG w10Build = 10586;
     RTL_OSVERSIONINFOEXW verInfo = { 0 };
     ULONG buildNo = 0;
 
@@ -260,7 +259,7 @@ NTSTATUS BBInitDynamicData( IN OUT PDYNAMIC_DATA pData )
         if (ver_short != WINVER_81)
             return STATUS_NOT_SUPPORTED;
     #elif defined (_WIN10_)
-        if (ver_short != WINVER_10 || verInfo.dwBuildNumber != w10Build)
+        if (ver_short != WINVER_10)
             return STATUS_NOT_SUPPORTED;
     #endif
 
@@ -330,21 +329,42 @@ NTSTATUS BBInitDynamicData( IN OUT PDYNAMIC_DATA pData )
                     pData->ExRemoveTable -= 0x5E;
                 break;
 
-                // Windows 10, build 10586
+            // Windows 10, build 14393/10586
             case WINVER_10:
-                pData->KExecOpt         = 0x1BF;
-                pData->Protection       = 0x6B2;
-                pData->ObjTable         = 0x418;
-                pData->VadRoot          = 0x610;
-                pData->NtCreateThdIndex = 0xB4;
-                pData->NtTermThdIndex   = 0x53;
-                pData->PrevMode         = 0x232;
-                pData->ExitStatus       = 0x6E0;
-                pData->MiAllocPage      = 0;
-                if (NT_SUCCESS( BBScanSection( "PAGE", (PCUCHAR)"\x48\x8D\x7D\x18\x48\x8B", 0xCC, 6, (PVOID)&pData->ExRemoveTable ) ))
-                    pData->ExRemoveTable   -= 0x5C;
-                break;
-
+				if (verInfo.dwBuildNumber == 10586)
+				{
+					pData->KExecOpt = 0x1BF;
+					pData->Protection = 0x6B2;
+					pData->ObjTable = 0x418;
+					pData->VadRoot = 0x610;
+					pData->NtCreateThdIndex = 0xB4;
+					pData->NtTermThdIndex = 0x53;
+					pData->PrevMode = 0x232;
+					pData->ExitStatus = 0x6E0;
+					pData->MiAllocPage = 0;
+					if (NT_SUCCESS(BBScanSection("PAGE", (PCUCHAR)"\x48\x8D\x7D\x18\x48\x8B", 0xCC, 6, (PVOID)&pData->ExRemoveTable)))
+						pData->ExRemoveTable -= 0x5C;
+					break;
+				}
+				else if (verInfo.dwBuildNumber == 14393)
+				{
+					pData->KExecOpt = 0x1BF;
+					pData->Protection = 0x6C2;
+					pData->ObjTable = 0x418;
+					pData->VadRoot = 0x620;
+					pData->NtCreateThdIndex = 0xB6;
+					pData->NtTermThdIndex = 0x53;
+					pData->PrevMode = 0x232;
+					pData->ExitStatus = 0x6F0;
+					pData->MiAllocPage = 0;
+					if (NT_SUCCESS(BBScanSection("PAGE", (PCUCHAR)"\x48\x8D\x7D\x18\x48\x8B", 0xCC, 6, (PVOID)&pData->ExRemoveTable)))
+						pData->ExRemoveTable -= 0x9C;
+					break;
+				}
+				else
+				{
+					return STATUS_NOT_SUPPORTED;
+				}
             default:
                 break;
         }


### PR DESCRIPTION
Since this Win10 update is likely to segment users into 10586 and 14393, I thought it might be wise to keep offsets for both.  

* Changed Windows 10 detection logic
* Protection 0x6B2 -> 0x6C2
* VadRoot 0x610 -> 0x620
* NtCreateThreadEx SSDT index 0xB4 -> 0xB6
* ExitStatus 0x6E0 -> 0x6F0
* ExRemoveTable offset 0x5C -> 0x9C

Thanks a lot DarthTon. Expect some more PRs from me very soon ;) .