### PR TITLE
Missing lock in RemoteHook::Remove

### DIFF
--- a/src/BlackBone/Process/RPC/RemoteHook.cpp
+++ b/src/BlackBone/Process/RPC/RemoteHook.cpp
@@ -178,6 +178,7 @@ NTSTATUS RemoteHook::AddReturnHookP( uint64_t ptr, fnCallback newFn, const void*
 void RemoteHook::Remove( uint64_t ptr )
 {
     // Restore hooked function
+    CSLock lck( _lock );
     if (_hooks.count( ptr ))
     {
         auto& hook = _hooks[ptr];


### PR DESCRIPTION
(Assumed from looking at other functions)