### PR TITLE
Fix #114

### DIFF
--- a/src/BlackBoneDrv/Loader.c
+++ b/src/BlackBoneDrv/Loader.c
@@ -787,6 +787,10 @@ NTSTATUS BBMapWorker( IN PVOID pArg )
         RtlInsertInvertedFunctionTable((PUCHAR)GetKernelBase( NULL ) + 0x1ED450, imageSection, pNTHeader->OptionalHeader.SizeOfImage );
     }*/
 
+    // Initialize kernel security cookie
+	if (NT_SUCCESS( status ))
+		BBCreateCookie( imageSection );
+    
     // Call entry point
     if (NT_SUCCESS( status ) && pNTHeader->OptionalHeader.AddressOfEntryPoint)
     {

--- a/src/BlackBoneDrv/Utils.h
+++ b/src/BlackBoneDrv/Utils.h
@@ -61,6 +61,13 @@ NTSTATUS BBFileExists( IN PUNICODE_STRING path );
 /// <returns>Status code</returns>
 NTSTATUS BBSearchPattern( IN PCUCHAR pattern, IN UCHAR wildcard, IN ULONG_PTR len, IN const VOID* base, IN ULONG_PTR size, OUT PVOID* ppFound );
 
+/// <summary>
+/// Setup image security cookie
+/// </summary>
+/// <param name="imageBase">Image base</param>
+/// <returns>Status code</returns>
+NTSTATUS BBCreateCookie( IN PVOID imageBase );
+
 //
 // Machine code generation routines
 //


### PR DESCRIPTION
Drivers compiled using WDK8+ will bugcheck with KERNEL_SECURITY_CHECK_FAILURE unless the security cookie in the PE header is set by the loader.  This change adds BBCreateCookie to BBMapWorker to satisfy this requirement (fixing #114).