### PR TITLE
Handle STATUS_PROCESS_IS_TERMINATING in EnumSections

### DIFF
--- a/src/BlackBone/Subsystem/NativeSubsystem.cpp
+++ b/src/BlackBone/Subsystem/NativeSubsystem.cpp
@@ -567,7 +567,7 @@ size_t Native::EnumPEHeaders( listModules& result )
     {
         auto status = VirtualQueryExT( memptr, &mbi );
 
-        if (status == STATUS_INVALID_PARAMETER || status == STATUS_ACCESS_DENIED)
+        if (status == STATUS_INVALID_PARAMETER || status == STATUS_ACCESS_DENIED || status == STATUS_PROCESS_IS_TERMINATING)
             break;
         else if (status != STATUS_SUCCESS)
             continue;


### PR DESCRIPTION
VirtualQueryEx can return STATUS_PROCESS_IS_TERMINATING.
I received this return code when using manual map on a closing process.
Since this case is not handled, EnumSection enters an infinite loop.