### PR TITLE
Compare the fix #148 and updated the Windos SDK version to slove compile errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,8 @@ GeneratedFiles*/
 *.opendb
 *.db
 *.sqlite
+/.vs
+*.db-shm
+*.db-wal
+*.json
+*.json

--- a/contrib/VersionHelpers.h
+++ b/contrib/VersionHelpers.h
@@ -80,6 +80,7 @@ IsWindowsVersionOrGreater( WORD wMajorVersion, WORD wMinorVersion, WORD wService
 
 		if (verInfo.wServicePackMajor > wServicePackMajor)
             return true;
+
 		else if (verInfo.wServicePackMajor < wServicePackMajor)
 		    return false;
 

--- a/contrib/VersionHelpers.h
+++ b/contrib/VersionHelpers.h
@@ -78,8 +78,10 @@ IsWindowsVersionOrGreater( WORD wMajorVersion, WORD wMinorVersion, WORD wService
         else if (verInfo.dwMinorVersion < wMinorVersion)
             return false;
 
-        if (verInfo.wServicePackMajor >= wServicePackMajor)
+		if (verInfo.wServicePackMajor > wServicePackMajor)
             return true;
+		else if (verInfo.wServicePackMajor < wServicePackMajor)
+		    return false;
 
         if (verInfo.dwBuildNumber >= dwBuild)
             return true;

--- a/src/BlackBone/BlackBone.vcxproj
+++ b/src/BlackBone/BlackBone.vcxproj
@@ -55,7 +55,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Xantos</RootNamespace>
     <ProjectName>BlackBone</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -222,7 +222,8 @@
     <LinkIncremental>false</LinkIncremental>
     <OutDir>$(SolutionDir)build\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(ProjectDir)\$(Platform)\$(Configuration)\</IntDir>
-    <IncludePath>$(ProjectDir)..\..\contrib;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)..\..\contrib;$(IncludePath);$(include)</IncludePath>
+    <LibraryPath>$(LibraryPath);$(lib)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release(XP)|Win32'">
     <LinkIncremental>false</LinkIncremental>

--- a/src/TestApp/TestApp.vcxproj
+++ b/src/TestApp/TestApp.vcxproj
@@ -54,7 +54,7 @@
     <ProjectGuid>{D31B07B5-C75F-4382-B07F-D95922764BD7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestApp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Since we have updated our visual studio to the latest version,the  default Windows SDK version is aslo changed to 10 and upper.The "include_path" embedded in VS instead of in ENV.
```c++
#include <cor.h>
#include <CorError.h>
```
These two files supported by Windows SDK 7.1a,but doesn't by Windows SDK 10,so I added "$(include)" and "$(lib)" to "include_path" and "lib_path" to fixed Blackbone compiled error.