### PR TITLE
Fix memory leaks, manual mapped modules not found, msvc2015 compat...

### DIFF
--- a/src/BlackBone/Config.h
+++ b/src/BlackBone/Config.h
@@ -7,7 +7,9 @@
 
 #if defined(_MSC_VER)
 
-    #define COMPILER_MSVC
+    #ifndef COMPILER_MSVC
+        #define COMPILER_MSVC 1
+    #endif
 
     #if defined(BLACKBONE_IMPORTS)
         #define BLACKBONE_API __declspec(dllimport)

--- a/src/BlackBone/Include/CallResult.h
+++ b/src/BlackBone/Include/CallResult.h
@@ -42,4 +42,58 @@ struct call_result_t
     inline T& operator *()  { return result_data.value(); }
 };
 }
+
+#else
+
+#include <memory>
+#include <cassert>
+
+namespace blackbone
+{
+    /// <summary>
+    /// Function result or failure status
+    /// </summary>
+    template <typename T>
+    struct call_result_t
+    {
+        NTSTATUS status = STATUS_UNSUCCESSFUL;          // Execution status
+        std::unique_ptr<T> result_data;                 // Returned value
+
+        call_result_t() = default;
+
+        call_result_t(T result_, NTSTATUS status_ = STATUS_SUCCESS)
+            : status(status_)
+            , result_data(std::make_unique<T>(std::move(result_)))
+        {
+            assert(result_data.get());
+        }
+
+        call_result_t(NTSTATUS status_)
+            : status(status_)
+        {
+            assert(status_ != STATUS_SUCCESS);
+        }
+
+
+    private:
+        inline T* value() {
+            if (!result_data) {
+                throw std::logic_error("bad optional access.");
+            }
+            return result_data.get();
+        }
+    public:
+
+        inline bool success() const { return NT_SUCCESS( status ); }
+        inline T& result() { return *value(); }
+        inline const T& result() const { return *value(); }
+        inline T result(const T& def_val) const { return result_data ? *result_data.get() : def_val; }
+
+        inline explicit operator bool() const { return NT_SUCCESS( status ); }
+        inline explicit operator T() const { return *value(); }
+
+        inline T* operator ->() { return value(); }
+        inline T& operator *() { return *value(); }
+    };
+}
 #endif

--- a/src/BlackBone/ManualMap/MMap.cpp
+++ b/src/BlackBone/ManualMap/MMap.cpp
@@ -169,8 +169,8 @@ call_result_t<ModuleDataPtr> MMap::MapImageInternal(
         else
         {
             img->imgMem.Write( offset, size, zeroBuf.get() );
-            if (!NT_SUCCESS( proc.memory().Free( img->imgMem.ptr() + offset, size ) ))
-                proc.memory().Protect( img->imgMem.ptr() + offset, size, PAGE_NOACCESS );
+            proc.memory().Protect( img->imgMem.ptr() + offset, size, PAGE_NOACCESS );
+            proc.memory().Free( img->imgMem.ptr() + offset, size, MEM_DECOMMIT );
         }
     };
 

--- a/src/BlackBone/ManualMap/MMap.cpp
+++ b/src/BlackBone/ManualMap/MMap.cpp
@@ -277,7 +277,7 @@ call_result_t<ModuleDataPtr> MMap::FindOrMapModule(
     auto& ldrEntry = pImage->ldrEntry;
 
     ldrEntry.fullPath = path;
-    ldrEntry.name = Utils::StripPath( path );
+    ldrEntry.name = Utils::ToLower( Utils::StripPath( path ) );
     pImage->flags = flags;
 
     // Load and parse image

--- a/src/BlackBone/ManualMap/Native/NtLoader.cpp
+++ b/src/BlackBone/ManualMap/Native/NtLoader.cpp
@@ -56,7 +56,7 @@ bool NtLdr::Init( eModType initFor /*= mt_default*/ )
     _nodeMap.clear();
 
     // Report errors
-#ifndef BLACBONE_NO_TRACE
+#ifndef BLACKBONE_NO_TRACE
     if (_LdrHeapBase == 0)
         BLACKBONE_TRACE( "NativeLdr: LdrHeapBase not found" );
     if (_LdrpHashTable == 0)

--- a/src/BlackBone/Misc/DynImport.h
+++ b/src/BlackBone/Misc/DynImport.h
@@ -3,6 +3,7 @@
 #include "../Include/Types.h"
 #include "../Include/Winheaders.h"
 #include "Utils.h"
+#include "InitOnce.h"
 
 #include <unordered_map>
 
@@ -29,6 +30,8 @@ public:
     template<typename T>
     inline T get( const std::string& name ) 
     {
+        blackbone::Initialize();
+
         CSLock lck( _mapGuard );
 
         auto iter = _funcs.find( name );

--- a/src/BlackBone/Misc/InitOnce.cpp
+++ b/src/BlackBone/Misc/InitOnce.cpp
@@ -125,6 +125,9 @@ private:
 
 std::unique_ptr<PatternLoader> g_PatternLoader;
 
+bool Initialize() {
+    static bool initialized = InitOnce::Exec();
+    return initialized;
+}
 bool InitOnce::_done = false;
-const bool g_Initialized = InitOnce::Exec();
 }

--- a/src/BlackBone/Misc/InitOnce.h
+++ b/src/BlackBone/Misc/InitOnce.h
@@ -1,5 +1,5 @@
 #pragma once
 namespace blackbone
 {
-extern const bool g_Initialized;
+bool Initialize();
 }

--- a/src/BlackBone/Misc/PatternLoader.cpp
+++ b/src/BlackBone/Misc/PatternLoader.cpp
@@ -118,7 +118,7 @@ const PatternData& PatternLoader::DoSearch()
     }
 
     // Report errors
-#ifndef BLACBONE_NO_TRACE
+#ifndef BLACKBONE_NO_TRACE
     if (_data.LdrpHandleTlsData64 == 0)
         BLACKBONE_TRACE( "PatternData: LdrpHandleTlsData64 not found" );
     if (_data.LdrpHandleTlsData32 == 0)

--- a/src/BlackBone/Misc/Trace.hpp
+++ b/src/BlackBone/Misc/Trace.hpp
@@ -10,7 +10,7 @@
 
 namespace blackbone
 {
-#ifndef BLACBONE_NO_TRACE
+#ifndef BLACKBONE_NO_TRACE
 
 inline void DoTraceV( const char* fmt, va_list va_args )
 {

--- a/src/BlackBone/Process/MemBlock.cpp
+++ b/src/BlackBone/Process/MemBlock.cpp
@@ -2,6 +2,7 @@
 #include "ProcessMemory.h"
 #include "ProcessCore.h"
 #include "../Subsystem/NativeSubsystem.h"
+#include "../Misc/Trace.hpp"
 
 namespace blackbone
 {
@@ -90,7 +91,7 @@ call_result_t<MemBlock> MemBlock::Allocate(
     ptr_t desired64 = desired;
     DWORD newProt = CastProtection( protection, process.core().DEP() );
     
-    NTSTATUS status = process.core().native()->VirtualAllocExT( desired64, size, MEM_COMMIT, newProt );
+    NTSTATUS status = process.core().native()->VirtualAllocExT( desired64, size, MEM_RESERVE | MEM_COMMIT, newProt );
     if (!NT_SUCCESS( status ))
     {
         desired64 = 0;
@@ -100,7 +101,9 @@ call_result_t<MemBlock> MemBlock::Allocate(
         else
             return status;
     }
-
+#ifdef _DEBUG
+    BLACKBONE_TRACE(L"Allocate: Allocating at address 0x%p (0x%X bytes)", static_cast<uintptr_t>(desired64), size);
+#endif
     return MemBlock( &process, desired64, size, protection, own );
 }
 

--- a/src/BlackBone/Process/Process.cpp
+++ b/src/BlackBone/Process/Process.cpp
@@ -21,7 +21,7 @@ Process::Process()
     , _nativeLdr( *this )
 {
     // Ensure InitOnce is called
-    auto i = g_Initialized;
+    auto i = blackbone::Initialize();
     UNREFERENCED_PARAMETER( i );
 }
 

--- a/src/BlackBone/Process/Process.cpp
+++ b/src/BlackBone/Process/Process.cpp
@@ -40,9 +40,10 @@ NTSTATUS Process::Attach( DWORD pid, DWORD access /*= DEFAULT_ACCESS_P*/ )
     Detach();
 
     auto status = _core.Open( pid, access );
+    /*
     if (NT_SUCCESS( status ) && (access & PROCESS_VM_WRITE))
         status = _remote.CreateRPCEnvironment();
-
+    */
     return status;
 }
 
@@ -56,6 +57,7 @@ NTSTATUS Process::Attach( HANDLE hProc )
     Detach();
 
     auto status = _core.Open( hProc );
+    /*
     if (NT_SUCCESS( status ))
     {
         if (!valid())
@@ -63,7 +65,7 @@ NTSTATUS Process::Attach( HANDLE hProc )
 
         _remote.CreateRPCEnvironment();
     }
-
+    */
     return status;
 }
 

--- a/src/BlackBone/Process/ProcessMemory.cpp
+++ b/src/BlackBone/Process/ProcessMemory.cpp
@@ -1,5 +1,6 @@
 #include "ProcessMemory.h"
 #include "Process.h"
+#include "../Misc/Trace.hpp"
 
 namespace blackbone
 {
@@ -37,6 +38,14 @@ call_result_t<MemBlock> ProcessMemory::Allocate( size_t size, DWORD protection /
 /// <returns>Status</returns>
 NTSTATUS ProcessMemory::Free( ptr_t pAddr, size_t size /*= 0*/, DWORD freeType /*= MEM_RELEASE*/ )
 {
+#ifdef _DEBUG
+    assert( freeType != MEM_RELEASE || size == 0 );
+    if (freeType == MEM_DECOMMIT) {
+        BLACKBONE_TRACE( L"Free: Decommit at address 0x%p (0x%x bytes)", static_cast<uintptr_t>(pAddr), size );
+    } else {
+        BLACKBONE_TRACE( L"Free: Free at address 0x%p", static_cast<uintptr_t>(pAddr) );
+    }
+#endif
     return _core.native()->VirtualFreeExT( pAddr, size, freeType );
 }
 

--- a/src/BlackBone/Process/ProcessModules.cpp
+++ b/src/BlackBone/Process/ProcessModules.cpp
@@ -571,7 +571,7 @@ ModuleDataPtr ProcessModules::AddManualModule( ModuleData mod )
 /// <param name="mt">Module type. 32 bit or 64 bit</param>
 void ProcessModules::RemoveManualModule( const std::wstring& filename, eModType mt )
 {
-    auto key = std::make_pair( filename, mt );
+    auto key = std::make_pair( Utils::ToLower( Utils::StripPath( filename ) ), mt );
     if (_modules.count( key ))
         _modules.erase( key );
 }

--- a/src/BlackBone/Process/RPC/RemoteExec.cpp
+++ b/src/BlackBone/Process/RPC/RemoteExec.cpp
@@ -493,10 +493,11 @@ NTSTATUS RemoteExec::CreateAPCEvent( DWORD threadID )
         if (!NT_SUCCESS( status ))
             return status;
 
-        auto fillAttributes = [this, len, pEventName]( auto& obAttr, auto& ustr )
+        wchar_t* pEvent = pEventName; //for MSVC 14 - 2015
+        auto fillAttributes = [this, len, pEvent]( auto& obAttr, auto& ustr )
         {
             ustr.Buffer = static_cast<decltype(ustr.Buffer)>(this->_userData.ptr() + ARGS_OFFSET + sizeof( obAttr ) + sizeof( ustr ));
-            ustr.Length = static_cast<USHORT>(wcslen( pEventName ) * sizeof( wchar_t ));
+            ustr.Length = static_cast<USHORT>(wcslen( pEvent ) * sizeof( wchar_t ));
             ustr.MaximumLength = static_cast<USHORT>(len);
 
             obAttr.Length = sizeof( obAttr );
@@ -504,7 +505,7 @@ NTSTATUS RemoteExec::CreateAPCEvent( DWORD threadID )
 
             NTSTATUS status  = this->_userData.Write( ARGS_OFFSET, obAttr );
             status |= this->_userData.Write( ARGS_OFFSET + sizeof( obAttr ), ustr );
-            status |= this->_userData.Write( ARGS_OFFSET + sizeof( obAttr ) + sizeof( ustr ), len, pEventName );
+            status |= this->_userData.Write( ARGS_OFFSET + sizeof( obAttr ) + sizeof( ustr ), len, pEvent );
             return status;
         };
 


### PR DESCRIPTION
- msvc2015 compatibility: the library doesn't compile right now with msvc2015, this commit fixes it (only the library, not the tests)
- fix BLACKBONE_NO_TRACE spelling: self explanatory
- fix multiple define warnings: COMPILER_MSVC is sometimes already defined, in that case, don't redefine it
- fix modules not being found: modules [are added in lowercase](https://github.com/DarthTon/Blackbone/blob/18637861ece3586bcb406541bbd674c8fcb2b7b9/src/BlackBone/Process/ProcessModules.cpp#L559), so they have to be looked up in lowercase aswell
- fix initonce deadlock on dllmain: right now the blackbone InitOnce function tries to dynamically load libraries. Therefore if blackbone is compiled in a dll, it deadlocks, because the loader lock is active while blackbone is trying to load libraries in InitOnce. This fixes it by initializing only when it's actually needed.
- fix memory leaks: blackbone leaks memory in the target process when manually mapping, this should fix it (SxS is still leaking though afaik)
- do not automatically create rpc environment on attach: This is unnecessary, because blackbone will already create that rpc environment when needed




