### PR TITLE
Removed search for "NtTerminateThread" in RemoteExec::ExecInNewThread

### DIFF
--- a/src/BlackBone/Process/RPC/RemoteExec.cpp
+++ b/src/BlackBone/Process/RPC/RemoteExec.cpp
@@ -58,10 +58,6 @@ NTSTATUS RemoteExec::ExecInNewThread(
         break;
     }
 
-    auto pExitThread = _mods.GetNtdllExport( "NtTerminateThread", switchMode ? mt_mod64 : mt_default );
-    if (!pExitThread)
-        return pExitThread.status;
-
     auto a = switchMode ? AsmFactory::GetAssembler( AsmFactory::asm64 ) 
                         : AsmFactory::GetAssembler( _process.core().isWow64() );
 


### PR DESCRIPTION
Removed redundant, probably heavyweight search for "NtTerminateThread" function in ntdll in RemoteExec::ExecInNewThread