### PR TITLE
Support for VS2019 (_MSC_VER 1920)

### DIFF
--- a/src/BlackBone/PE/ImageNET.h
+++ b/src/BlackBone/PE/ImageNET.h
@@ -6,6 +6,10 @@
 
 #include <map>
 
+#if _MSC_VER >= 1920
+    #include <string>
+#endif
+
 #pragma warning(push)
 #pragma warning(disable : 4091)
 #include "cor.h"


### PR DESCRIPTION
Pretty straightforward, solves:
`error C2039: 'wstring': is not a member of 'std' (compiling source file PE\ImageNET.cpp)`
Which causes a cascade of other errors within ImageNET.