### PR TITLE
Added switch to force manual mapping

### DIFF
--- a/src/BlackBone/ManualMap/MMap.h
+++ b/src/BlackBone/ManualMap/MMap.h
@@ -100,6 +100,7 @@ enum eLoadFlags
     MapInHighMem    = 0x20,     // Try to map image in address space beyond 4GB limit
     RebaseProcess   = 0x40,     // If target image is an .exe file, process base address will be replaced with mapped module value
     NoThreads       = 0x80,     // Don't create new threads, use hijacking
+	ForceRemap		= 0x100,	// Force remapping module even if it's already loaded
 
     NoExceptions    = 0x01000,   // Do not create custom exception handler
     PartialExcept   = 0x02000,   // Only create Inverted function table, without VEH


### PR DESCRIPTION
In this case, the module is not going to be added to the internal modules list, but it seems to be logical :) The new flag is "ForceRemap".

I haven't run your tests, as I'm not yet sure how they works, but I doubt it would break anything.

I'm not sure if:
`pMod = std::make_shared<const ModuleData>(ldrEntry);`
is leaking anything or if it's correct at all, it might be solved any better way, please check that out.

Thanks!