### PR TITLE
fix memory api return value usage 

### DIFF
--- a/src/BlackBone/Process/Threads/Thread.cpp
+++ b/src/BlackBone/Process/Threads/Thread.cpp
@@ -185,9 +185,8 @@ NTSTATUS Thread::SetContext( _CONTEXT64& ctx, bool dontSuspend /*= false*/ )
 /// <returns>Status code</returns>
 NTSTATUS Thread::Terminate( DWORD code /*= 0*/ )
 {
-    SetLastNtStatus( STATUS_SUCCESS );
-    TerminateThread( _handle, code );
-    return LastNtStatus();
+    auto r = TerminateThread(_handle, code);
+    return r != 0 ? STATUS_SUCCESS : LastNtStatus();
 }
 
 /// <summary>

--- a/src/BlackBone/Subsystem/NativeSubsystem.cpp
+++ b/src/BlackBone/Subsystem/NativeSubsystem.cpp
@@ -332,7 +332,7 @@ ptr_t Native::getPEB( _PEB32* ppeb )
     {
         ptr_t ptr = 0;
         if (NT_SUCCESS( SAFE_NATIVE_CALL( NtQueryInformationProcess, _hProcess, ProcessWow64Information, &ptr, (ULONG)sizeof( ptr ), nullptr ) ) && ppeb)
-            ReadProcessMemory( _hProcess, reinterpret_cast<LPCVOID>(ptr), ppeb, sizeof(_PEB32), NULL );
+            ReadProcessMemory( _hProcess, reinterpret_cast<LPCVOID>(ptr), ppeb, sizeof(*ppeb), NULL );
 
         return ptr;
     }
@@ -349,7 +349,7 @@ ptr_t Native::getPEB( _PEB64* ppeb )
     ULONG bytes = 0;
 
     if (NT_SUCCESS( SAFE_NATIVE_CALL( NtQueryInformationProcess, _hProcess, ProcessBasicInformation, &pbi, (ULONG)sizeof( pbi ), &bytes ) ) && ppeb)
-        ReadProcessMemory( _hProcess, pbi.PebBaseAddress, ppeb, sizeof(_PEB32), NULL );
+        ReadProcessMemory( _hProcess, pbi.PebBaseAddress, ppeb, sizeof(*ppeb), NULL );
 
     return reinterpret_cast<ptr_t>(pbi.PebBaseAddress);
 }
@@ -373,7 +373,7 @@ ptr_t Native::getTEB( HANDLE hThread, _TEB32* pteb )
         ULONG bytes = 0;
 
         if (NT_SUCCESS( SAFE_NATIVE_CALL( NtQueryInformationThread, hThread, (THREADINFOCLASS)0, &tbi, (ULONG)sizeof( tbi ), &bytes ) ) && pteb)
-            ReadProcessMemory( _hProcess, (const uint8_t*)tbi.TebBaseAddress + 0x2000, pteb, sizeof(_TEB32), NULL );
+            ReadProcessMemory( _hProcess, (const uint8_t*)tbi.TebBaseAddress + 0x2000, pteb, sizeof(*pteb), NULL );
 
         return tbi.TebBaseAddress + 0x2000;
     }
@@ -391,7 +391,7 @@ ptr_t Native::getTEB( HANDLE hThread, _TEB64* pteb )
     ULONG bytes = 0;
 
     if (NT_SUCCESS( SAFE_NATIVE_CALL( NtQueryInformationThread, hThread, (THREADINFOCLASS)0, &tbi, (ULONG)sizeof( tbi ), &bytes ) ) && pteb)
-        ReadProcessMemory( _hProcess, reinterpret_cast<LPCVOID>(tbi.TebBaseAddress), pteb, sizeof(_TEB64), NULL );
+        ReadProcessMemory( _hProcess, reinterpret_cast<LPCVOID>(tbi.TebBaseAddress), pteb, sizeof(*pteb), NULL );
 
     return tbi.TebBaseAddress;
 }

--- a/src/BlackBone/Subsystem/Wow64Subsystem.cpp
+++ b/src/BlackBone/Subsystem/Wow64Subsystem.cpp
@@ -2,6 +2,7 @@
 #include "../Misc/DynImport.h"
 #include "../Include/Macro.h"
 #include <3rd_party/rewolf-wow64ext/src/wow64ext.h>
+#include "../Misc/Trace.hpp"
 
 namespace blackbone
 {
@@ -214,9 +215,8 @@ NTSTATUS NativeWow64::GetThreadContextT( HANDLE hThread, _CONTEXT32& ctx )
     }
     else
     {
-        SetLastNtStatus( STATUS_SUCCESS );
-        GetThreadContext( hThread, reinterpret_cast<PCONTEXT>(&ctx) );
-        return LastNtStatus();
+        auto r = GetThreadContext(hThread, reinterpret_cast<PCONTEXT>(&ctx));
+        return r != 0 ? STATUS_SUCCESS : LastNtStatus();
     }
 }
 
@@ -251,9 +251,8 @@ NTSTATUS NativeWow64::SetThreadContextT( HANDLE hThread, _CONTEXT32& ctx )
     }
     else
     {
-        SetLastNtStatus( STATUS_SUCCESS );
-        SetThreadContext( hThread, reinterpret_cast<const CONTEXT*>(&ctx) );
-        return LastNtStatus();
+        auto r = SetThreadContext(hThread, reinterpret_cast<const CONTEXT*>(&ctx));
+        return r != 0 ? STATUS_SUCCESS : LastNtStatus();
     }
 }
 

--- a/src/BlackBone/Subsystem/x86Subsystem.cpp
+++ b/src/BlackBone/Subsystem/x86Subsystem.cpp
@@ -52,9 +52,8 @@ NTSTATUS x86Native::VirtualQueryExT( ptr_t lpAddress, PMEMORY_BASIC_INFORMATION6
 /// <returns>Status code</returns>
 NTSTATUS x86Native::GetThreadContextT( HANDLE hThread, _CONTEXT32& ctx )
 {
-    SetLastNtStatus( STATUS_SUCCESS );
-    GetThreadContext( hThread, reinterpret_cast<PCONTEXT>(&ctx) );
-    return LastNtStatus();
+    auto r = GetThreadContext(hThread, reinterpret_cast<PCONTEXT>(&ctx));
+    return r != 0 ? STATUS_SUCCESS : LastNtStatus();
 }
 
 /// <summary>
@@ -77,9 +76,8 @@ NTSTATUS x86Native::GetThreadContextT( HANDLE /*hThread*/, _CONTEXT64& /*ctx*/ )
 /// <returns>Status code</returns>
 NTSTATUS x86Native::SetThreadContextT( HANDLE hThread, _CONTEXT32& ctx )
 {
-    SetLastNtStatus( STATUS_SUCCESS );
-    SetThreadContext( hThread, reinterpret_cast<const CONTEXT*>(&ctx) );
-    return LastNtStatus();
+    auto r = SetThreadContext(hThread, reinterpret_cast<const CONTEXT*>(&ctx));
+    return r != 0 ? STATUS_SUCCESS : LastNtStatus();
 }
 
 /// <summary>


### PR DESCRIPTION
Windows api does not have any guarantee that ntstatus will remain unchanged after a successful call, neither it have any guarantee of its value in this case.
Though it is working most of the time, correct way is to check call return value.