### PR TITLE
Fixed/Finished RemoteLocalHook; Improvements for PatternSearch

### DIFF
--- a/src/BlackBone/Patterns/PatternSearch.cpp
+++ b/src/BlackBone/Patterns/PatternSearch.cpp
@@ -9,28 +9,28 @@
 namespace blackbone
 {
 
-PatternSearch::PatternSearch( const std::vector<uint8_t>& pattern )
-    : _pattern( pattern )
+PatternSearch::PatternSearch( const std::vector<uint8_t>& pattern, size_t logAlignment /*= 0*/ )
+    : _pattern( pattern ), logAlignment(logAlignment)
 {
 }
 
-PatternSearch::PatternSearch( const std::initializer_list<uint8_t>&& pattern )
-    : _pattern( pattern )
+PatternSearch::PatternSearch( const std::initializer_list<uint8_t>&& pattern, size_t logAlignment /*= 0*/ )
+    : _pattern( pattern ), logAlignment(logAlignment)
 {
 }
 
-PatternSearch::PatternSearch( const std::string& pattern )
-    : _pattern( pattern.begin(), pattern.end() )
+PatternSearch::PatternSearch( const std::string& pattern, size_t logAlignment /*= 0*/ )
+    : _pattern( pattern.begin(), pattern.end() ), logAlignment(logAlignment)
 {
 }
 
-PatternSearch::PatternSearch( const char* pattern, size_t len /*= 0*/ )
-    : _pattern( pattern, pattern + (len ? len : strlen( pattern )) )
+PatternSearch::PatternSearch( const char* pattern, size_t len /*= 0*/, size_t logAlignment /*= 0*/ )
+    : _pattern( pattern, pattern + (len ? len : strlen( pattern )) ), logAlignment(logAlignment)
 {
 }
 
-PatternSearch::PatternSearch( const uint8_t* pattern, size_t len /*= 0*/ )
-    : _pattern( pattern, pattern + (len ? len : strlen( (const char*)pattern )) )
+PatternSearch::PatternSearch( const uint8_t* pattern, size_t len /*= 0*/, size_t logAlignment /*= 0*/ )
+    : _pattern( pattern, pattern + (len ? len : strlen( (const char*)pattern )) ), logAlignment(logAlignment)
 { 
 }
 
@@ -44,37 +44,42 @@ PatternSearch::PatternSearch( const uint8_t* pattern, size_t len /*= 0*/ )
 /// <param name="out">Found results</param>
 /// <param name="value_offset">Value that will be added to resulting addresses</param>
 /// <returns>Number of found addresses</returns>
-size_t PatternSearch::Search( 
-    uint8_t wildcard, 
-    void* scanStart, 
-    size_t scanSize, 
-    std::vector<ptr_t>& out, 
-    ptr_t value_offset /*= 0*/ 
+bool PatternSearch::SearchWithHandler(
+    uint8_t wildcard,
+        void* scanStart,
+        size_t scanSize,
+		MatchHandler handler,
+        ptr_t value_offset /*= 0*/
     ) const
 {
     const uint8_t* cstart = (const uint8_t*)scanStart;
     const uint8_t* cend   = cstart + scanSize;
+
+    // TODO: Would it be beneficial to use logAlignment here as well?
 
     auto comparer = [&wildcard]( uint8_t val1, uint8_t val2 )
     {
         return (val1 == val2 || val2 == wildcard);
     };
 
-    for (;;)
+    bool running = true;
+    while (running)
     {
         const uint8_t* res = std::search( cstart, cend, _pattern.begin(), _pattern.end(), comparer );
         if (res >= cend)
             break;
 
         if (value_offset != 0)
-            out.emplace_back( REBASE( res, scanStart, value_offset ) );
+        	running = !handler( REBASE( res, scanStart, value_offset ) );
+            //out.emplace_back( REBASE( res, scanStart, value_offset ) );
         else
-            out.emplace_back( reinterpret_cast<ptr_t>(res) );
+            //out.emplace_back( reinterpret_cast<ptr_t>(res) );
+        	running = !handler( reinterpret_cast<ptr_t>(res) );
 
         cstart = res + _pattern.size();
     }
 
-    return out.size();
+    return !running;
 }
 
 /// <summary>
@@ -86,20 +91,23 @@ size_t PatternSearch::Search(
 /// <param name="out">Found results</param>
 /// <param name="value_offset">Value that will be added to resulting addresses</param>
 /// <returns>Number of found addresses</returns>
-size_t PatternSearch::Search( 
-    void* scanStart,
-    size_t scanSize, 
-    std::vector<ptr_t>& out,
-    ptr_t value_offset /*= 0*/ 
-    ) const
+bool PatternSearch::SearchWithHandler(
+	void* scanStart,
+	size_t scanSize,
+	MatchHandler handler,
+	ptr_t value_offset /*= 0*/
+	) const
 {
-    size_t bad_char_skip[UCHAR_MAX + 1];
+	size_t bad_char_skip[UCHAR_MAX + 1];
 
     const uint8_t* haystack = reinterpret_cast<const uint8_t*>(scanStart);
+    const uint8_t* haystackEnd = haystack + scanSize - _pattern.size();
     const uint8_t* needle   = &_pattern[0];
     uintptr_t       nlen     = _pattern.size();
     uintptr_t       scan     = 0;
     uintptr_t       last     = nlen - 1;
+    size_t alignMask		 = 0xFFFFFFFFFFFFFFFFL << logAlignment;
+    size_t alignOffs		 = (1 << logAlignment) - 1;
 
     //
     // Preprocess
@@ -113,26 +121,33 @@ size_t PatternSearch::Search(
     //
     // Search
     //
-    while (scanSize >= static_cast<size_t>(nlen))
+    bool running = true;
+    //while (haystack <= haystackEnd  &&  out.size() < maxMatches)
+    while (haystack <= haystackEnd  &&  running)
     {
         for (scan = last; haystack[scan] == needle[scan]; --scan)
         {
             if (scan == 0)
             {
                 if (value_offset != 0)
-                    out.emplace_back( REBASE( haystack, scanStart, value_offset ) );
+                    //out.emplace_back( REBASE( haystack, scanStart, value_offset ) );
+                	running = !handler( REBASE( haystack, scanStart, value_offset ) );
                 else
-                    out.emplace_back( reinterpret_cast<ptr_t>(haystack) );
+                    //out.emplace_back( reinterpret_cast<ptr_t>(haystack) );
+                	running = !handler( reinterpret_cast<ptr_t>(haystack) );
 
                 break;
             }
         }
 
-        scanSize -= bad_char_skip[haystack[last]];
         haystack += bad_char_skip[haystack[last]];
+
+        if (logAlignment != 0) {
+        	haystack = (const uint8_t*) (size_t(haystack+alignOffs) & alignMask);
+        }
     }
 
-    return out.size();
+    return !running;
 }
 
 /// <summary>
@@ -144,23 +159,24 @@ size_t PatternSearch::Search(
 /// <param name="scanSize">Size of region to scan</param>
 /// <param name="out">Found results</param>
 /// <returns>Number of found addresses</returns>
-size_t PatternSearch::SearchRemote( 
-    Process& remote, 
-    uint8_t wildcard, 
-    ptr_t scanStart, 
-    size_t scanSize, 
-    std::vector<ptr_t>& out 
+bool PatternSearch::SearchRemoteWithHandler(
+    Process& remote,
+    uint8_t wildcard,
+    ptr_t scanStart,
+    size_t scanSize,
+    MatchHandler handler
     ) const
 {
     uint8_t *pBuffer = reinterpret_cast<uint8_t*>(VirtualAlloc( NULL, scanSize, MEM_COMMIT, PAGE_READWRITE ));
 
+    bool stopped = false;
     if (pBuffer && remote.memory().Read( scanStart, scanSize, pBuffer ) == STATUS_SUCCESS)
-        Search( wildcard, pBuffer, scanSize, out, scanStart );
+    	stopped = SearchWithHandler( wildcard, pBuffer, scanSize, handler, scanStart );
 
     if (pBuffer)
         VirtualFree( pBuffer, 0, MEM_RELEASE );
 
-    return out.size();
+    return stopped;
 }
 
 /// <summary>
@@ -171,22 +187,23 @@ size_t PatternSearch::SearchRemote(
 /// <param name="scanSize">Size of region to scan</param>
 /// <param name="out">Found results</param>
 /// <returns>Number of found addresses</returns>
-size_t PatternSearch::SearchRemote( 
-    Process& remote, 
-    ptr_t scanStart, 
-    size_t scanSize, 
-    std::vector<ptr_t>& out 
+bool PatternSearch::SearchRemoteWithHandler(
+    Process& remote,
+    ptr_t scanStart,
+    size_t scanSize,
+    MatchHandler handler
     ) const
 {
     uint8_t *pBuffer = reinterpret_cast<uint8_t*>(VirtualAlloc( NULL, scanSize, MEM_COMMIT, PAGE_READWRITE ));
 
+    bool stopped = false;
     if (pBuffer && remote.memory().Read( scanStart, scanSize, pBuffer ) == STATUS_SUCCESS)
-        Search( pBuffer, scanSize, out, scanStart );
+    	stopped = SearchWithHandler( pBuffer, scanSize, handler, scanStart );
 
     if (pBuffer)
         VirtualFree( pBuffer, 0, MEM_RELEASE );
 
-    return out.size();
+    return stopped;
 }
 
 /// <summary>
@@ -197,22 +214,21 @@ size_t PatternSearch::SearchRemote(
 /// <param name="wildcard">Pattern wildcard</param>
 /// <param name="out">Found results</param>
 /// <returns>Number of found addresses</returns>
-size_t PatternSearch::SearchRemoteWhole( 
-    Process& remote, 
-    bool useWildcard, 
-    uint8_t wildcard, 
-    std::vector<ptr_t>& out 
+bool PatternSearch::SearchRemoteWholeWithHandler(
+    Process& remote,
+    bool useWildcard,
+    uint8_t wildcard,
+    MatchHandler handler
     ) const
 {
     MEMORY_BASIC_INFORMATION64 mbi = { 0 };
     size_t  bufsize = 1 * 1024 * 1024;  // 1 MB
     uint8_t *buf = reinterpret_cast<uint8_t*>(VirtualAlloc( 0, bufsize, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE ));
 
-    out.clear();
-
     auto native = remote.core().native();
 
-    for (ptr_t memptr = native->minAddr(); memptr < native->maxAddr(); memptr = mbi.BaseAddress + mbi.RegionSize)
+    bool running = true;
+    for (ptr_t memptr = native->minAddr(); memptr < native->maxAddr()  &&  running; memptr = mbi.BaseAddress + mbi.RegionSize)
     {
         auto status = remote.core().native()->VirtualQueryExT( memptr, &mbi );
 
@@ -237,14 +253,150 @@ size_t PatternSearch::SearchRemoteWhole(
             continue;
 
         if (useWildcard)
-            Search( wildcard, buf, static_cast<size_t>(mbi.RegionSize), out, memptr );
+        	running = !SearchWithHandler( wildcard, buf, static_cast<size_t>(mbi.RegionSize), handler, memptr );
         else
-            Search( buf, static_cast<size_t>(mbi.RegionSize), out, memptr );
+        	running = !SearchWithHandler( buf, static_cast<size_t>(mbi.RegionSize), handler, memptr );
     }
 
     VirtualFree( buf, 0, MEM_RELEASE );
 
-    return out.size();
+    return !running;
+}
+
+
+
+
+/// <summary>
+/// Default pattern matching with wildcards.
+/// std::search is approximately 2x faster than naive approach.
+/// </summary>
+/// <param name="wildcard">Pattern wildcard</param>
+/// <param name="scanStart">Starting address</param>
+/// <param name="scanSize">Size of region to scan</param>
+/// <param name="out">Found results</param>
+/// <param name="value_offset">Value that will be added to resulting addresses</param>
+/// <returns>Number of found addresses</returns>
+size_t PatternSearch::Search(
+    uint8_t wildcard,
+    void* scanStart,
+    size_t scanSize,
+    std::vector<ptr_t>& out,
+    ptr_t value_offset /*= 0*/,
+	size_t maxMatches /*= SIZE_MAX*/
+    ) const
+{
+	if (out.size() >= maxMatches)
+		return out.size();
+
+	auto handler = std::bind(PatternSearch::collectAllMatchHandler, std::placeholders::_1, std::ref(out), maxMatches);
+	SearchWithHandler(wildcard, scanStart, scanSize, handler, value_offset);
+
+	return out.size();
+}
+
+/// <summary>
+/// Full pattern match, no wildcards.
+/// Uses Boyer–Moore–Horspool algorithm.
+/// </summary>
+/// <param name="scanStart">Starting address</param>
+/// <param name="scanSize">Size of region to scan</param>
+/// <param name="out">Found results</param>
+/// <param name="value_offset">Value that will be added to resulting addresses</param>
+/// <returns>Number of found addresses</returns>
+size_t PatternSearch::Search( 
+    void* scanStart,
+    size_t scanSize, 
+    std::vector<ptr_t>& out,
+    ptr_t value_offset /*= 0*/,
+	size_t maxMatches /*= SIZE_MAX*/
+    ) const
+{
+	if (out.size() >= maxMatches)
+		return out.size();
+
+	auto handler = std::bind(PatternSearch::collectAllMatchHandler, std::placeholders::_1, std::ref(out), maxMatches);
+	SearchWithHandler(scanStart, scanSize, handler, value_offset);
+
+	return out.size();
+}
+
+/// <summary>
+/// Search pattern in remote process
+/// </summary>
+/// <param name="remote">Remote process</param>
+/// <param name="wildcard">Pattern wildcard</param>
+/// <param name="scanStart">Starting address</param>
+/// <param name="scanSize">Size of region to scan</param>
+/// <param name="out">Found results</param>
+/// <returns>Number of found addresses</returns>
+size_t PatternSearch::SearchRemote( 
+    Process& remote, 
+    uint8_t wildcard, 
+    ptr_t scanStart, 
+    size_t scanSize, 
+    std::vector<ptr_t>& out,
+	size_t maxMatches /*= SIZE_MAX*/
+    ) const
+{
+	if (out.size() >= maxMatches)
+		return out.size();
+
+	auto handler = std::bind(PatternSearch::collectAllMatchHandler, std::placeholders::_1, std::ref(out), maxMatches);
+	SearchRemoteWithHandler(remote, wildcard, scanStart, scanSize, handler);
+
+	return out.size();
+}
+
+/// <summary>
+/// Search pattern in remote process
+/// </summary>
+/// <param name="remote">Remote process</param>
+/// <param name="scanStart">Starting address</param>
+/// <param name="scanSize">Size of region to scan</param>
+/// <param name="out">Found results</param>
+/// <returns>Number of found addresses</returns>
+size_t PatternSearch::SearchRemote( 
+    Process& remote, 
+    ptr_t scanStart, 
+    size_t scanSize, 
+    std::vector<ptr_t>& out,
+	size_t maxMatches /*= SIZE_MAX*/
+    ) const
+{
+	if (out.size() >= maxMatches)
+		return out.size();
+
+	auto handler = std::bind(PatternSearch::collectAllMatchHandler, std::placeholders::_1, std::ref(out), maxMatches);
+	SearchRemoteWithHandler(remote, scanStart, scanSize, handler);
+
+	return out.size();
+}
+
+/// <summary>
+/// Search pattern in whole address space of remote process
+/// </summary>
+/// <param name="remote">Remote process</param>
+/// <param name="useWildcard">True if pattern contains wildcards</param>
+/// <param name="wildcard">Pattern wildcard</param>
+/// <param name="out">Found results</param>
+/// <returns>Number of found addresses</returns>
+size_t PatternSearch::SearchRemoteWhole( 
+    Process& remote, 
+    bool useWildcard, 
+    uint8_t wildcard, 
+    std::vector<ptr_t>& out,
+	size_t maxMatches /*= SIZE_MAX*/
+    ) const
+{
+	out.clear();
+
+	if (out.size() >= maxMatches)
+		return out.size();
+
+	auto handler = std::bind(PatternSearch::collectAllMatchHandler, std::placeholders::_1, std::ref(out), maxMatches);
+	SearchRemoteWholeWithHandler(remote, useWildcard, wildcard, handler);
+
+	return out.size();
 }
 
 

--- a/src/BlackBone/Patterns/PatternSearch.h
+++ b/src/BlackBone/Patterns/PatternSearch.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 #include <initializer_list>
 
 namespace blackbone
@@ -12,13 +13,110 @@ namespace blackbone
 class PatternSearch
 {
 public:
-    BLACKBONE_API PatternSearch( const std::vector<uint8_t>& pattern );
-    BLACKBONE_API PatternSearch( const std::initializer_list<uint8_t>&& pattern );
-    BLACKBONE_API PatternSearch( const std::string& pattern );
-    BLACKBONE_API PatternSearch( const char* pattern, size_t len = 0 );
-    BLACKBONE_API PatternSearch( const uint8_t* pattern, size_t len = 0 );
+	/// <summary>
+	/// Callback to handle a matching address for the Search*WithHandler() methods.
+	/// If the handler returns true, the search is stopped, else the search continues.
+	/// </summary>
+	typedef std::function<bool (ptr_t)> MatchHandler;
+
+public:
+	// logAlignment can be used to speed-up the search in some cases. For example, if you know that the start of the pattern
+	// is always 8-byte-aligned, you can pass logAlignment=3 (2^3 = 8) to skip searching at all addresses that aren't multiples
+	// of 8. Note that for smaller alignments and depending on the exact pattern, this may not always be faster (it may even be
+	// a tiny bit slower), so profile it if you care about performance.
+    BLACKBONE_API PatternSearch( const std::vector<uint8_t>& pattern, size_t logAlignment = 0 );
+    BLACKBONE_API PatternSearch( const std::initializer_list<uint8_t>&& pattern, size_t logAlignment = 0 );
+    BLACKBONE_API PatternSearch( const std::string& pattern, size_t logAlignment = 0 );
+    BLACKBONE_API PatternSearch( const char* pattern, size_t len = 0, size_t logAlignment = 0 );
+    BLACKBONE_API PatternSearch( const uint8_t* pattern, size_t len = 0, size_t logAlignment = 0 );
 
     BLACKBONE_API ~PatternSearch() = default;
+
+    /// <summary>
+    /// Default pattern matching with wildcards and a callback handler for matches.
+    /// std::search is approximately 2x faster than naive approach.
+    /// </summary>
+    /// <param name="wildcard">Pattern wildcard</param>
+    /// <param name="scanStart">Starting address</param>
+    /// <param name="scanSize">Size of region to scan</param>
+    /// <param name="handler">Callback that is called for every match. If it returns true, the search is stopped prematurely.</param>
+    /// <param name="value_offset">Value that will be added to resulting addresses</param>
+    /// <returns>true if the callback handler ever returned true (i.e. the search ended prematurely), false otherwise.</returns>
+    BLACKBONE_API bool SearchWithHandler(
+        uint8_t wildcard,
+        void* scanStart,
+        size_t scanSize,
+		MatchHandler handler,
+        ptr_t value_offset = 0
+        ) const;
+
+    /// <summary>
+    /// Full pattern match, no wildcards, with a callback handler for matches.
+    /// Uses Boyer–Moore–Horspool algorithm.
+    /// </summary>
+    /// <param name="scanStart">Starting address</param>
+    /// <param name="scanSize">Size of region to scan</param>
+    /// <param name="handler">Callback that is called for every match. If it returns true, the search is stopped prematurely.</param>
+    /// <param name="value_offset">Value that will be added to resulting addresses</param>
+    /// <returns>true if the callback handler ever returned true (i.e. the search ended prematurely), false otherwise.</returns>
+    BLACKBONE_API bool SearchWithHandler(
+        void* scanStart,
+        size_t scanSize,
+		MatchHandler handler,
+        ptr_t value_offset = 0
+        ) const;
+
+    /// <summary>
+    /// Search pattern in remote process with a callback handler for matches
+    /// </summary>
+    /// <param name="remote">Remote process</param>
+    /// <param name="wildcard">Pattern wildcard</param>
+    /// <param name="scanStart">Starting address</param>
+    /// <param name="scanSize">Size of region to scan</param>
+    /// <param name="handler">Callback that is called for every match. If it returns true, the search is stopped prematurely.</param>
+    /// <returns>true if the callback handler ever returned true (i.e. the search ended prematurely), false otherwise.</returns>
+    BLACKBONE_API bool SearchRemoteWithHandler(
+        class Process& remote,
+        uint8_t wildcard,
+        ptr_t scanStart,
+        size_t scanSize,
+        MatchHandler handler
+        ) const;
+
+    /// <summary>
+    /// Search pattern in remote process with a callback handler for matches
+    /// </summary>
+    /// <param name="remote">Remote process</param>
+    /// <param name="scanStart">Starting address</param>
+    /// <param name="scanSize">Size of region to scan</param>
+    /// <param name="handler">Callback that is called for every match. If it returns true, the search is stopped prematurely.</param>
+    /// <returns>true if the callback handler ever returned true (i.e. the search ended prematurely), false otherwise.</returns>
+    BLACKBONE_API bool SearchRemoteWithHandler(
+        class Process& remote,
+        ptr_t scanStart,
+        size_t scanSize,
+        MatchHandler handler
+        ) const;
+
+    /// <summary>
+    /// Search pattern in whole address space of remote process with a callback handler for matches
+    /// </summary>
+    /// <param name="remote">Remote process</param>
+    /// <param name="useWildcard">True if pattern contains wildcards</param>
+    /// <param name="wildcard">Pattern wildcard</param>
+    /// <param name="handler">Callback that is called for every match. If it returns true, the search is stopped prematurely.</param>
+    /// <returns>true if the callback handler ever returned true (i.e. the search ended prematurely), false otherwise.</returns>
+    BLACKBONE_API bool SearchRemoteWholeWithHandler(
+        class Process& remote,
+        bool useWildcard,
+        uint8_t wildcard,
+        MatchHandler handler
+        ) const;
+
+
+
+
+
 
     /// <summary>
     /// Default pattern matching with wildcards.
@@ -29,13 +127,15 @@ public:
     /// <param name="scanSize">Size of region to scan</param>
     /// <param name="out">Found results</param>
     /// <param name="value_offset">Value that will be added to resulting addresses</param>
+    /// <param name="maxMatches">Maximum number of matches to collect</param>
     /// <returns>Number of found addresses</returns>
     BLACKBONE_API size_t Search( 
         uint8_t wildcard, 
         void* scanStart, 
         size_t scanSize, 
         std::vector<ptr_t>& out, 
-        ptr_t value_offset = 0 
+        ptr_t value_offset = 0,
+		size_t maxMatches = SIZE_MAX
         ) const;
 
     /// <summary>
@@ -46,12 +146,14 @@ public:
     /// <param name="scanSize">Size of region to scan</param>
     /// <param name="out">Found results</param>
     /// <param name="value_offset">Value that will be added to resulting addresses</param>
+    /// <param name="maxMatches">Maximum number of matches to collect</param>
     /// <returns>Number of found addresses</returns>
     BLACKBONE_API size_t Search( 
         void* scanStart, 
         size_t scanSize, 
         std::vector<ptr_t>& out, 
-        ptr_t value_offset = 0 
+        ptr_t value_offset = 0,
+		size_t maxMatches = SIZE_MAX
         ) const;
 
     /// <summary>
@@ -62,13 +164,15 @@ public:
     /// <param name="scanStart">Starting address</param>
     /// <param name="scanSize">Size of region to scan</param>
     /// <param name="out">Found results</param>
+    /// <param name="maxMatches">Maximum number of matches to collect</param>
     /// <returns>Number of found addresses</returns>
     BLACKBONE_API size_t SearchRemote( 
         class Process& remote, 
         uint8_t wildcard, 
         ptr_t scanStart,
         size_t scanSize, 
-        std::vector<ptr_t>& out 
+        std::vector<ptr_t>& out,
+		size_t maxMatches = SIZE_MAX
         ) const;
 
     /// <summary>
@@ -78,12 +182,14 @@ public:
     /// <param name="scanStart">Starting address</param>
     /// <param name="scanSize">Size of region to scan</param>
     /// <param name="out">Found results</param>
+    /// <param name="maxMatches">Maximum number of matches to collect</param>
     /// <returns>Number of found addresses</returns>
     BLACKBONE_API size_t SearchRemote( 
         class Process& remote, 
         ptr_t scanStart, 
         size_t scanSize, 
-        std::vector<ptr_t>& out 
+        std::vector<ptr_t>& out,
+		size_t maxMatches = SIZE_MAX
         ) const;
 
     /// <summary>
@@ -93,16 +199,26 @@ public:
     /// <param name="useWildcard">True if pattern contains wildcards</param>
     /// <param name="wildcard">Pattern wildcard</param>
     /// <param name="out">Found results</param>
+    /// <param name="maxMatches">Maximum number of matches to collect</param>
     /// <returns>Number of found addresses</returns>
     BLACKBONE_API size_t SearchRemoteWhole( 
         class Process& remote, 
         bool useWildcard, 
         uint8_t wildcard, 
-        std::vector<ptr_t>& out 
+        std::vector<ptr_t>& out,
+		size_t maxMatches = SIZE_MAX
         ) const;
 
 private:
+    static inline bool collectAllMatchHandler(ptr_t addr, std::vector<ptr_t>& out, size_t maxMatches)
+    {
+    	out.emplace_back(addr);
+		return out.size() >= maxMatches;
+    }
+
+private:
     std::vector<uint8_t> _pattern;      // Pattern to search
+    size_t logAlignment;
 };
 
 }

--- a/src/BlackBone/Process/MemBlock.h
+++ b/src/BlackBone/Process/MemBlock.h
@@ -134,6 +134,23 @@ public:
         );
 
     /// <summary>
+    /// Allocate new memory block as close to a given location as possible.
+    /// </summary>
+    /// <param name="process">Process memory routines</param>
+    /// <param name="size">Block size</param>
+    /// <param name="desired">Desired base address of new block</param>
+    /// <param name="protection">Win32 Memory protection flags</param>
+    /// <param name="own">false if caller will be responsible for block deallocation</param>
+    /// <returns>Memory block. If failed - returned block will be invalid</returns>
+    BLACKBONE_API static call_result_t<MemBlock> AllocateClosest(
+    	class ProcessMemory& process,
+        size_t size,
+        ptr_t desired,
+        DWORD protection = PAGE_EXECUTE_READWRITE,
+        bool own = true
+    	);
+
+    /// <summary>
     /// Reallocate existing block for new size
     /// </summary>
     /// <param name="size">New block size</param>

--- a/src/BlackBone/Process/ProcessMemory.cpp
+++ b/src/BlackBone/Process/ProcessMemory.cpp
@@ -29,6 +29,11 @@ call_result_t<MemBlock> ProcessMemory::Allocate( size_t size, DWORD protection /
     return MemBlock::Allocate( *this, size, desired, protection, own );
 }
 
+call_result_t<MemBlock> ProcessMemory::AllocateClosest( size_t size, DWORD protection /*= PAGE_EXECUTE_READWRITE*/, ptr_t desired /*= 0*/, bool own /*= true*/ )
+{
+    return MemBlock::AllocateClosest( *this, size, desired, protection, own );
+}
+
 /// <summary>
 /// Free memory
 /// </summary>

--- a/src/BlackBone/Process/ProcessMemory.h
+++ b/src/BlackBone/Process/ProcessMemory.h
@@ -34,6 +34,16 @@ public:
     BLACKBONE_API call_result_t<MemBlock> Allocate( size_t size, DWORD protection = PAGE_EXECUTE_READWRITE, ptr_t desired = 0, bool own = true );
 
     /// <summary>
+    /// Allocate new memory block as close to a desired location as possible
+    /// </summary>
+    /// <param name="size">Block size</param>
+    /// <param name="protection">Memory protection</param>
+    /// <param name="desired">Desired base address of new block</param>
+    /// <param name="desired">false if caller will be responsible for block deallocation</param>
+    /// <returns>Memory block. If failed - returned block will be invalid</returns>
+    BLACKBONE_API call_result_t<MemBlock> AllocateClosest( size_t size, DWORD protection = PAGE_EXECUTE_READWRITE, ptr_t desired = 0, bool own = true );
+
+    /// <summary>
     /// Free memory
     /// </summary>
     /// <param name="pAddr">Memory address to release.</param>

--- a/src/BlackBone/Process/RPC/RemoteLocalHook.cpp
+++ b/src/BlackBone/Process/RPC/RemoteLocalHook.cpp
@@ -3,6 +3,15 @@
 #include "../Process.h"
 #include "../../Asm/LDasm.h"
 
+#include <cstdio>
+
+
+
+// Must be enough to hold the displaced original code (instr_align(sizeof(1*jmp64))) plus the return jmp (sizeof(1*jmp64))
+#define THUNK_MAX_SIZE 50
+
+
+
 namespace blackbone
 {
 
@@ -16,98 +25,164 @@ RemoteLocalHook::~RemoteLocalHook()
     Restore();
 }
 
-NTSTATUS RemoteLocalHook::AllocateMem( ptr_t /*address*/, size_t codeSize )
+NTSTATUS RemoteLocalHook::AllocateMem( ptr_t address, size_t hookCodeSize )
 {
-    auto pagesize = _process.core().native()->pageSize();
-    auto size = Align( codeSize, pagesize ) + Align( sizeof( _ctx ), pagesize );
+	auto pagesize = _process.core().native()->pageSize();
+    auto size = Align( hookCodeSize + THUNK_MAX_SIZE, pagesize );
 
-    auto allocation = _process.memory().Allocate( size, PAGE_EXECUTE_READWRITE );
+    auto allocation = _process.memory().AllocateClosest( size, PAGE_EXECUTE_READWRITE, address );
     if (!allocation)
         return allocation.status;
 
     _hookData   = std::move( allocation.result() );
-    _pHookCode  = _hookData.ptr();
-    _pThunkCode = _pHookCode + _hookData.size() - pagesize;
-
     return allocation.status;
+}
+
+void RemoteLocalHook::SetJumpStrategy(eJumpStrategy strategy)
+{
+	_jumpStrategy = strategy;
+}
+
+void RemoteLocalHook::SetJumpRegister(const asmjit::X86GpReg& reg)
+{
+	_jumpRegister = &reg;
+}
+
+size_t RemoteLocalHook::GetDisplacedOriginalCode( uint8_t* code )
+{
+	if (!_prepared)
+		return 0;
+	if (code)
+		memcpy(code, _ctx.origCode, _ctx.origCodeSize);
+	return _ctx.origCodeSize;
+}
+
+NTSTATUS RemoteLocalHook::PrepareHook( ptr_t address, size_t maxHookSize )
+{
+	_ctx.address = address;
+    NTSTATUS status = AllocateMem( address, maxHookSize );
+    if (!NT_SUCCESS( status ))
+        return status;
+
+    _ctx.thunkAddr = _hookData.ptr() + maxHookSize;
+
+
+    bool x64 = !_process.core().isWow64();
+
+    _ctx.hookJumpCodeSize = GenerateJump( _ctx.hookJumpCode, _hookData.ptr(), address, x64 );
+
+    status = CopyOldCode( x64 );
+    if (!NT_SUCCESS( status )) {
+    	_hookData.Free();
+    	_hookData = MemBlock();
+		return status;
+    }
+
+    _prepared = true;
+
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS RemoteLocalHook::SetHook( ptr_t address, asmjit::Assembler& hook )
 {
-    _address = address;
-    NTSTATUS status = AllocateMem( address, hook.getCodeSize() );
-    if (!NT_SUCCESS( status ))
-        return status;
-
-    return _process.core().isWow64() ? SetHook32( address, hook ) : SetHook64( address, hook );
-}
-
-NTSTATUS RemoteLocalHook::SetHook32( ptr_t address, asmjit::Assembler& hook )
-{
-    NTSTATUS status = STATUS_SUCCESS;
+	bool x64 = !_process.core().isWow64();
     auto& mem = _process.memory();
 
-    if (!CopyOldCode( address, false ))
-        return STATUS_PARTIAL_COPY;
+    NTSTATUS status = STATUS_SUCCESS;
 
-    _ctx.hook32.codeSize = 5;
-    _ctx.hook32.jmp.opcode = 0xE9;
-    _ctx.hook32.jmp.ptr = static_cast<int32_t>(_pThunkCode - address - 5);
+    if (!_prepared) {
+    	status = PrepareHook( address, hook.getCodeSize() );
+    	if (!NT_SUCCESS( status )) {
+    		return status;
+    	}
+    }
 
-    uint8_t buf[0x1000] = { 0 };
-    hook.setBaseAddress( _hookData.ptr<int32_t>() );
-    hook.relocCode( buf );
+    uint8_t hookCode[256];
+    uint8_t* heapHookCode = nullptr; // Only used if hook.getCodeSize() > sizeof(hookCode)
 
-    mem.Write( _pHookCode, buf );
-    mem.Write( _pThunkCode, _ctx.hook32.codeSize + _ctx.hook32.jmp_size, _ctx.hook32.original_code );
+    if (hook.getCodeSize() > sizeof(hookCode)) {
+    	heapHookCode = new uint8_t[hook.getCodeSize()];
+    }
 
-    DWORD flOld = 0;
-    mem.Protect( address, sizeof( _ctx.hook32.jmp_code ), PAGE_EXECUTE_READWRITE, &flOld );
-    status = mem.Write( address, _ctx.hook32.jmp_code );
-    mem.Protect( address, sizeof( _ctx.hook32.jmp_code ), flOld );
+    hook.setBaseAddress( _hookData.ptr() );
+	hook.relocCode( heapHookCode ? heapHookCode : hookCode );
 
-    if (NT_SUCCESS( status ))
-        _hooked = true;
+	uint8_t jmpBackCode[sizeof(_ctx.hookJumpCode)];
+	uint8_t jmpBackCodeSize;
 
-    return status;
-}
+	jmpBackCodeSize = GenerateJump(jmpBackCode, address + _ctx.origCodeSize, _hookData.ptr() + hook.getCodeSize() + _ctx.origCodeSize, x64);
 
-NTSTATUS RemoteLocalHook::SetHook64( ptr_t /*address*/, asmjit::Assembler& /*hook*/ )
-{
-    _hook64 = true;
-    return STATUS_NOT_IMPLEMENTED;
+	if (hook.getCodeSize() > (_ctx.thunkAddr - _hookData.ptr())) {
+    	// Can happen if PrepareHook() was called manually with maxCodeSize < hook.getCodeSize().
+		delete[] heapHookCode;
+    	return STATUS_NO_MEMORY;
+    }
+
+    mem.Write( _hookData.ptr(), hook.getCodeSize(), heapHookCode ? heapHookCode : hookCode );
+	mem.Write( _ctx.thunkAddr, _ctx.origCodeSize, _ctx.patchedOrigCode );
+	mem.Write( _ctx.thunkAddr + _ctx.origCodeSize, jmpBackCodeSize, jmpBackCode );
+
+	// Fill region between end of hook and start of thunk with nop. This region is normally empty, but can be non-empty
+	// if PrepareHook() was called manually with maxCodeSize > hook.getCodeSize().
+	for (ptr_t addr = _hookData.ptr() + hook.getCodeSize() ; addr < _ctx.thunkAddr ; addr++)
+	{
+		uint8_t nop = 0x90;
+		mem.Write(addr, nop);
+	}
+
+	delete[] heapHookCode;
+
+	DWORD flOld = 0;
+	mem.Protect( address, _ctx.hookJumpCodeSize, PAGE_EXECUTE_READWRITE, &flOld );
+	status = mem.Write( address, _ctx.hookJumpCodeSize, _ctx.hookJumpCode );
+	mem.Protect( address, _ctx.hookJumpCodeSize, flOld );
+
+	if (NT_SUCCESS( status ))
+		_hooked = true;
+
+	return status;
 }
 
 NTSTATUS RemoteLocalHook::Restore()
 {
-    if (!_hooked)
-        return STATUS_SUCCESS;
+    NTSTATUS status = STATUS_SUCCESS;
 
-    DWORD flOld = 0;
-    _process.memory().Protect( _address, sizeof( _ctx.hook32.jmp_code ), PAGE_EXECUTE_READWRITE, &flOld );
-    NTSTATUS status = _process.memory().Write( _address, _ctx.hook32.codeSize, _ctx.hook32.original_code );
-    _process.memory().Protect( _address, sizeof( _ctx.hook32.jmp_code ), flOld );
-    
-    if (NT_SUCCESS( status ))
-    {
-        _hookData.Free();
-        _pHookCode = _pThunkCode = 0;
-        _address = 0;
-        _hooked = false;
-    }
+	if (_hooked) {
+		DWORD flOld = 0;
+		_process.memory().Protect( _ctx.address, _ctx.hookJumpCodeSize, PAGE_EXECUTE_READWRITE, &flOld );
+		status = _process.memory().Write( _ctx.address, _ctx.origCodeSize, _ctx.origCode );
+		_process.memory().Protect( _ctx.address, _ctx.hookJumpCodeSize, flOld );
+
+		if (!NT_SUCCESS( status )) {
+			return status;
+		}
+	}
+	if (_hookData.valid()) {
+		_hookData.Free();
+		_hookData = MemBlock();
+	}
+
+	_prepared = false;
+	_hooked = false;
 
     return status;
 }
 
-bool RemoteLocalHook::CopyOldCode( ptr_t address, bool x64 )
+NTSTATUS RemoteLocalHook::CopyOldCode( bool x64 )
 {
-    _process.memory().Read( address, sizeof( _ctx.hook32.original_code ), _ctx.hook32.original_code );
+	NTSTATUS status = STATUS_SUCCESS;
+
+	_process.memory().Read( _ctx.address, sizeof( _ctx.origCode ), _ctx.origCode );
+	memcpy(_ctx.patchedOrigCode, _ctx.origCode, sizeof(_ctx.patchedOrigCode));
 
     // Store original bytes
-    uint8_t* src = _ctx.hook32.original_code;
-    uint8_t* old = (uint8_t*)(_hookData.ptr() + _hookData.size() - _process.core().native()->pageSize());
-    uint32_t all_len = 0;
+	uint8_t* src = _ctx.origCode;
+	ptr_t newAddr = _ctx.thunkAddr;
+    uint32_t thunkSize = 0;
     ldasm_data ld = { 0 };
+
+    const int64_t diffMinVals[] = {0ll, -128ll, -32768ll, -8388608ll, -2147483648ll, -549755813888ll, -140737488355328ll, -36028797018963968ll, -9223372036854775808ll};
+    const int64_t diffMaxVals[] = {0ll, 127ll, 32767ll, 8388607ll, 2147483647ll, 549755813887ll, 140737488355327ll, 36028797018963967ll, 9223372036854775807ll};
 
     do
     {
@@ -117,7 +192,7 @@ bool RemoteLocalHook::CopyOldCode( ptr_t address, bool x64 )
         if (ld.flags & F_INVALID
             || (len == 1 && (src[ld.opcd_offset] == 0xCC || src[ld.opcd_offset] == 0xC3))
             || (len == 3 && src[ld.opcd_offset] == 0xC2)
-            || len + all_len > 128)
+            || len + thunkSize > 128)
         {
             break;
         }
@@ -125,49 +200,106 @@ bool RemoteLocalHook::CopyOldCode( ptr_t address, bool x64 )
         // if instruction has relative offset, calculate new offset 
         if (ld.flags & F_RELATIVE)
         {
-            int32_t diff = 0;
+        	int32_t diff = 0;
             const uintptr_t ofst = (ld.disp_offset != 0 ? ld.disp_offset : ld.imm_offset);
             const uintptr_t sz = ld.disp_size != 0 ? ld.disp_size : ld.imm_size;
 
             memcpy( &diff, src + ofst, sz );
 
-            if(x64)
-            {
-                // exit if jump is greater then 2GB
-                /*if (_abs64( src + len + diff - old ) > INT_MAX)
-                {
-                    break;
-                }
-                else
-                {
-                    diff += static_cast<int32_t>(src - old);
-                    memcpy( old + ofst, &diff, sz );
-                }*/
+            // An attempted (partial) solution to https://github.com/DarthTon/Blackbone/issues/418
+            // TODO: Do NOT adjust the offset if it points to WITHIN the code that's being moved!
+
+            int64_t newDiff = ((int64_t) diff) + (((ptr_t) (_ctx.address+thunkSize))-newAddr);
+
+            if (newDiff < diffMinVals[sz]  ||  newDiff > diffMaxVals[sz]) {
+            	status = STATUS_NOT_IMPLEMENTED;
+            	break;
             }
-            else
-            {
-                //diff += src - old;
-                memcpy( src + ofst, &diff, sz );
-            }
+
+            memcpy(_ctx.patchedOrigCode + thunkSize + ofst, &newDiff, sz);
         }
 
         src += len;
-        old += len;
-        all_len += len;
+        newAddr += len;
+        thunkSize += len;
+    } while (thunkSize < _ctx.hookJumpCodeSize);
 
-    } while (all_len < sizeof( _ctx.hook32.jmp_code ));
+    assert(thunkSize <= MaxOriginalCodeLen);
 
-    // Failed to copy old code, use backup plan
-    if (all_len >= sizeof( _ctx.hook32.jmp_code ))
+    if (thunkSize < _ctx.hookJumpCodeSize)
     {
-        _ctx.hook32.jmp_size = 5;
-        _ctx.hook32.codeSize = all_len;
-        *src = 0xE9;
-        //*(int32_t*)(src + 1) = (int32_t)address + all_len - (int32_t)old - 5;
-        return true;
+    	// TODO: Anything else we can do now?
+    }
+    else
+    {
+    	_ctx.origCodeSize = thunkSize;
     }
 
-    return false;
+    return status;
+}
+
+uint8_t RemoteLocalHook::GenerateJump( uint8_t* code, ptr_t toAddr, ptr_t fromAddr, bool x64 ) const
+{
+	uint8_t size;
+
+	auto asmp = AsmFactory::GetAssembler();
+	auto& a = *asmp;
+
+	int64_t relJmp = toAddr >= fromAddr ? (int64_t) (toAddr-fromAddr) : -(int64_t)(fromAddr-toAddr);
+
+	if (x64  &&  _abs64( relJmp ) > INT32_MAX)
+	{
+		switch (_jumpStrategy)
+		{
+		case JumpPushMovRet:
+			// A relatively non-intrusive way to jmp far on x86_64, leaving all registers intact.
+			// As described on Nikolay Igotti's blog:
+			//		https://web.archive.org/web/20090504135800/http://blogs.sun.com/nike/entry/long_absolute_jumps_on_amd64
+			// See also Gil Dabah's blog post, where it's #3:
+			//		https://www.ragestorm.net/blogs/?p=107
+
+			// push toAddr[0:31]
+			*code = 0x68;
+			*((uint32_t*) (code+1)) = (uint32_t) (toAddr & 0xFFFFFFFF);
+
+			if ((toAddr >> 32) != 0)
+			{
+				// mov [rsp+4], toAddr[32:63]
+				*((uint32_t*) (code+5)) = 0x042444C7;
+				*((uint32_t*) (code+9)) = (uint32_t) (toAddr >> 32);
+
+				// ret
+				*(code+13) = 0xC3;
+
+				size = 14;
+			}
+			else
+			{
+				// ret
+				*(code+5) = 0xC3;
+				size = 6;
+			}
+			break;
+		case JumpMovRegRet:
+			// Alternative method that overwrites a register, but keeps the stack untouched. See #2:
+			//		https://www.ragestorm.net/blogs/?p=107
+			a->mov(*_jumpRegister, (uint64_t) toAddr);
+			a->jmp(*_jumpRegister);
+			size = a->relocCode(code);
+			break;
+		}
+	}
+	else
+	{
+		// jmp rel toAddr
+		*code = 0xE9;
+		*((int32_t*) (code+1)) = (int32_t) (relJmp - 5);
+
+		size = 5;
+	}
+
+	assert(size <= sizeof(_ctx.hookJumpCode));
+	return size;
 }
 
 }

--- a/src/BlackBone/Process/RPC/RemoteLocalHook.h
+++ b/src/BlackBone/Process/RPC/RemoteLocalHook.h
@@ -6,44 +6,9 @@
 #include "../MemBlock.h"
 
 
+
 namespace blackbone
 {
-
-/// <summary>
-/// Hook data, sizeof = 0x50 bytes
-/// </summary>
-#pragma pack(push, 1)
-struct HookCtx32
-{
-    uint32_t codeSize;          // Size of saved code
-    uint32_t jmp_size;          // Size of jump from thunk to original
-    uint8_t original_code[29];  // Original function code
-
-    union
-    {
-        uint8_t jmp_code[5];    // Jump instruction
-        struct  
-        {
-            uint8_t opcode; 
-            int32_t ptr;
-        } jmp;
-    };
-};
-
-struct HookCtx64
-{
-    uint64_t dst_ptr;           // Target address
-    uint32_t codeSize;          // Size of saved code
-    uint8_t original_code[32];  // Original function code
-    uint8_t far_jmp[6];         // Far jump code
-};
-#pragma pack(pop)
-
-union HookCtx
-{
-    HookCtx32 hook32;
-    HookCtx64 hook64;
-};
 
 
 /// <summary>
@@ -52,34 +17,73 @@ union HookCtx
 class RemoteLocalHook
 {
 public:
+	// Must be large enough to hold ANY jump this code uses
+	static const size_t MaxHookJumpCodeLen = 14;
+
+	// The displaced code should be at most 1 hook length + 1 instruction - 1 byte (if the hook jump overlaps with only the
+	// first byte of the following instruction), and x86_64 instructions can be at most 15 bytes.
+	static const size_t MaxOriginalCodeLen = MaxHookJumpCodeLen + 14;
+
+	static const size_t MaxPatchedOriginalCodeLen = MaxOriginalCodeLen;
+
+	enum eJumpStrategy
+	{
+		JumpPushMovRet,
+		JumpMovRegRet
+	};
+
+private:
+	/// <summary>
+	/// Hook data
+	/// </summary>
+	#pragma pack(push, 1)
+	struct HookCtx
+	{
+		ptr_t address; // Hooked address in original code
+		ptr_t thunkAddr;
+		uint8_t origCodeSize; // Size of displaced original code
+		uint8_t origCode[MaxOriginalCodeLen]; // Copy of displaced original code
+		uint8_t patchedOrigCode[MaxPatchedOriginalCodeLen];
+		uint8_t hookJumpCode[MaxHookJumpCodeLen];
+		uint8_t hookJumpCodeSize;
+	};
+	#pragma pack(pop)
+
+public:
     RemoteLocalHook( class Process& process );
     ~RemoteLocalHook();
 
+    void SetJumpStrategy(eJumpStrategy strategy);
+    void SetJumpRegister(const asmjit::X86GpReg& reg);
+
     NTSTATUS SetHook( ptr_t address, asmjit::Assembler& hook );
     NTSTATUS Restore();
+
+    NTSTATUS PrepareHook( ptr_t address, size_t maxHookSize );
+
+    size_t GetDisplacedOriginalCode( uint8_t* code = nullptr );
+
+    bool isHooked() const { return _hooked; }
 
 private:
     RemoteLocalHook( const RemoteLocalHook& ) = delete;
     RemoteLocalHook& operator = (const RemoteLocalHook&) = delete;
 
-    NTSTATUS AllocateMem( ptr_t address, size_t codeSize );
+    NTSTATUS AllocateMem( ptr_t address, size_t hookCodeSize );
 
-    NTSTATUS SetHook32( ptr_t address, asmjit::Assembler& hook );
+    NTSTATUS CopyOldCode( bool x64 );
 
-    NTSTATUS SetHook64( ptr_t address, asmjit::Assembler& hook );
-
-    bool CopyOldCode( ptr_t address, bool x64 );
+    uint8_t GenerateJump( uint8_t* code, ptr_t toAddr, ptr_t fromAddr, bool x64 ) const;
 
 private:
     class Process& _process;
     HookCtx _ctx;
     MemBlock _hookData;
-    ptr_t _pHookCode = 0;
-    ptr_t _pThunkCode = 0;
-    ptr_t _address = 0;
+    eJumpStrategy _jumpStrategy = JumpPushMovRet;
+    const asmjit::X86GpReg* _jumpRegister = &asmjit::host::rax;
 
+    bool _prepared = false;
     bool _hooked = false;
-    bool _hook64 = false;
 };
 
 }


### PR DESCRIPTION
Mainly 3 changes:

1. Added MemBlock::AllocateClosest() to allocate memory as close to an address as possible. Searches for free memory regions of sufficient size left and right of the given address. Used for RemoteLocalHook to keep the thunk code close to the hook location.
2. Overhauled and finished code in RemoteLocalHook (https://github.com/DarthTon/Blackbone/issues/417). It's working now, on both x86 and x86_64. Different jump strategies can be selected for x86_64 if the jump location is not within 2GB. Rewriting of relative jmps and such in the displaced original code is still not handled completely (https://github.com/DarthTon/Blackbone/issues/418).
3. Improvements for PatternSearch: Optional address-aligned search (for speedup); calling handler functions (e.g. lambdas) on match; stopping the search prematurely if the handler function requests it.

On a source level, this shouldn't break anything that was working before. 1 is just an additional method. 2 was unfinished and abandoned before, so I suppose it can only be an improvement. 3 adds new methods, and adds new parameters with default values to existing methods. It does change the implementation of the existing methods (which now just call the handler-based versions), but the corresponding unit tests still ran fine, and I've used PatternSearch in my own program without problems.

I'm using VS2019, so someone should probably see if it compiles under VS2017 before merging, though I don't see why it wouldn't...