### PR TITLE
Add iterator declaration

### DIFF
--- a/src/BlackBone/Process/ProcessModules.cpp
+++ b/src/BlackBone/Process/ProcessModules.cpp
@@ -7,6 +7,7 @@
 #include "../Symbols/SymbolData.h"
 #include "../Asm/AsmFactory.h"
 
+#include <iterator>
 #include <memory>
 #include <type_traits>
 


### PR DESCRIPTION
was getting build errors trying to update Xenos to work with the latest Blackbone version and found out the iterator declaration was missing. I can update Xenos too as soon as this gets approved.