### PR TITLE
fix remote exec from x32 to x64 process

### DIFF
--- a/src/BlackBone/Process/RPC/RemoteExec.cpp
+++ b/src/BlackBone/Process/RPC/RemoteExec.cpp
@@ -54,7 +54,7 @@ NTSTATUS RemoteExec::ExecInNewThread(
         break;
 
     case blackbone::AutoSwitch:
-        switchMode = _process.barrier().type == wow_64_32;
+        switchMode = _process.barrier().type == wow_32_64;
         break;
     }
 


### PR DESCRIPTION
used incorrect enum of opposite direction 