### PR TITLE
Support binding RemoteFunctionBase to a thread

### DIFF
--- a/src/BlackBone/Process/RPC/RemoteFunction.hpp
+++ b/src/BlackBone/Process/RPC/RemoteFunction.hpp
@@ -52,9 +52,10 @@ public:
     };
 
 public:
-    RemoteFunctionBase( Process& proc, ptr_t ptr )
+    RemoteFunctionBase( Process& proc, ptr_t ptr, ThreadPtr boundThread = nullptr )
         : _process( proc )
         , _ptr( ptr )
+		, _boundThread(boundThread)
     {
         static_assert(
             (... && !std::is_reference_v<Args>),
@@ -68,6 +69,9 @@ public:
         uint64_t tmpResult = 0;
         NTSTATUS status = STATUS_SUCCESS;
         auto a = AsmFactory::GetAssembler( _process.core().isWow64() );
+
+        if (!contextThread)
+        	contextThread = _boundThread;
 
         // Ensure RPC environment exists
         status = _process.remote().CreateRPCEnvironment( Worker_None, contextThread != nullptr );
@@ -155,7 +159,9 @@ public:
     auto MakeArguments( const std::tuple<Args...>& args ) 
     { 
         return CallArguments( args, std::index_sequence_for<Args...>() ); 
-    }      
+    }
+
+    void BindToThread(ThreadPtr thread) { _boundThread = thread; }
 
     bool valid() const { return _ptr != 0; }
     explicit operator bool() const { return valid(); }
@@ -163,6 +169,7 @@ public:
 private:
     Process& _process;
     ptr_t _ptr = 0;
+    ThreadPtr _boundThread = nullptr;
 };
 
 // Remote function pointer
@@ -178,8 +185,8 @@ class RemoteFunction <R( __cdecl* )(Args...)> : public RemoteFunctionBase<cc_cde
 public:
     using RemoteFunctionBase<cc_cdecl, R, Args...>::RemoteFunctionBase;
 
-    RemoteFunction( Process& proc, R( __cdecl* ptr )(Args...) )
-        : RemoteFunctionBase<cc_cdecl, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr) )
+    RemoteFunction( Process& proc, R( __cdecl* ptr )(Args...), ThreadPtr boundThread = nullptr )
+        : RemoteFunctionBase<cc_cdecl, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr), boundThread )
     { 
     }
 };
@@ -192,8 +199,8 @@ class RemoteFunction <R( __stdcall* )(Args...)> : public RemoteFunctionBase<cc_s
 public:
     using RemoteFunctionBase<cc_stdcall, R, Args...>::RemoteFunctionBase;
 
-    RemoteFunction( Process& proc, R( __stdcall* ptr )(Args...) )
-        : RemoteFunctionBase<cc_stdcall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr) )
+    RemoteFunction( Process& proc, R( __stdcall* ptr )(Args...), ThreadPtr boundThread = nullptr )
+        : RemoteFunctionBase<cc_stdcall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr), boundThread )
     { 
     }
 };
@@ -204,8 +211,8 @@ class RemoteFunction <R( __thiscall* )(Args...)> : public RemoteFunctionBase<cc_
 public:
     using RemoteFunctionBase<cc_thiscall, R, Args...>::RemoteFunctionBase;
 
-    RemoteFunction( Process& proc, R( __thiscall* ptr )(Args...) )
-        : RemoteFunctionBase<cc_thiscall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr) )
+    RemoteFunction( Process& proc, R( __thiscall* ptr )(Args...), ThreadPtr boundThread = nullptr )
+        : RemoteFunctionBase<cc_thiscall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr), boundThread )
     { 
     }
 };
@@ -216,8 +223,8 @@ class RemoteFunction <R( __fastcall* )(Args...)> : public RemoteFunctionBase<cc_
 public:
     using RemoteFunctionBase<cc_fastcall, R, Args...>::RemoteFunctionBase;
 
-    RemoteFunction( Process& proc, R( __fastcall* ptr )(Args...) )
-        : RemoteFunctionBase<cc_fastcall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr) )
+    RemoteFunction( Process& proc, R( __fastcall* ptr )(Args...), ThreadPtr boundThread = nullptr )
+        : RemoteFunctionBase<cc_fastcall, R, Args...>( proc, reinterpret_cast<ptr_t>(ptr), boundThread )
     { 
     }
 };
@@ -229,9 +236,9 @@ public:
 /// <param name="ptr">Function address in the remote process</param>
 /// <returns>Function object</returns>
 template<typename T>
-RemoteFunction<T> MakeRemoteFunction( Process& process, ptr_t ptr )
+RemoteFunction<T> MakeRemoteFunction( Process& process, ptr_t ptr, ThreadPtr boundThread = nullptr )
 {
-    return RemoteFunction<T>( process, ptr );
+    return RemoteFunction<T>( process, ptr, boundThread );
 }
 
 /// <summary>
@@ -240,9 +247,9 @@ RemoteFunction<T> MakeRemoteFunction( Process& process, ptr_t ptr )
 /// <param name="ptr">Function address in the remote process</param>
 /// <returns>Function object</returns>
 template<typename T>
-RemoteFunction<T> MakeRemoteFunction( Process& process, T ptr )
+RemoteFunction<T> MakeRemoteFunction( Process& process, T ptr, ThreadPtr boundThread = nullptr )
 {
-    return RemoteFunction<T>( process, ptr );
+    return RemoteFunction<T>( process, ptr, boundThread );
 }
 
 /// <summary>
@@ -252,10 +259,10 @@ RemoteFunction<T> MakeRemoteFunction( Process& process, T ptr )
 /// <param name="name_ord">Function name or ordinal</param>
 /// <returns>Function object</returns>
 template<typename T>
-RemoteFunction<T> MakeRemoteFunction( Process& process, const std::wstring& modName, const char* name_ord )
+RemoteFunction<T> MakeRemoteFunction( Process& process, const std::wstring& modName, const char* name_ord, ThreadPtr boundThread = nullptr )
 {
     auto ptr = process.modules().GetExport( modName, name_ord );
-    return RemoteFunction<T>( process, ptr ? ptr->procAddress : 0 );
+    return RemoteFunction<T>( process, ptr ? ptr->procAddress : 0, boundThread );
 }
 
 }


### PR DESCRIPTION
This avoids having to supply a contextThread for every call to RemoteFunctionBase::Call().

Useful if you want to do an RPC multiple times, always in the same thread.