### PR TITLE
fix Test CallLoop bugs when builded with win32

### DIFF
--- a/src/BlackBone/Process/RPC/RemoteExec.cpp
+++ b/src/BlackBone/Process/RPC/RemoteExec.cpp
@@ -553,6 +553,11 @@ NTSTATUS RemoteExec::PrepareCallAssembly(
     }
         
     a.GenPrologue();
+    if (_process.core().isWow64())
+    {
+        a->pusha();
+        a->pushf();
+    }
     a.GenCall( pfn, args, cc );
 
     // Retrieve result from XMM0 or ST0
@@ -571,6 +576,11 @@ NTSTATUS RemoteExec::PrepareCallAssembly(
     }
 
     AddReturnWithEvent( a, mt_default, retType );
+    if (_process.core().isWow64())
+    {
+        a->popf();
+        a->popa();
+    }
     a.GenEpilogue();
 
     return STATUS_SUCCESS;


### PR DESCRIPTION
There were bugs in CallLoop When I run BlackboneTest on win10,  So I fixed it.