### PR TITLE
Support for Win11_23H2 and Win11_24H2

### DIFF
--- a/src/3rd_party/VersionApi.h
+++ b/src/3rd_party/VersionApi.h
@@ -31,6 +31,8 @@ enum eBuildThreshold
     Build_20H1 = 19041,
     Build_21H2 = 22000,
     Build_22H2 = 22621,
+    Build_23H2 = 22631,
+    Build_24H2 = 26100,
     Build_RS_MAX = 99999,
 };
 
@@ -51,7 +53,9 @@ enum eVerShort
     Win10_19H2,     // Windows 10 November 2019 update
     Win10_20H1,     // Windows 10 April 2020 update
     Win11_21H2,     // Windows 11
-    Win11_22H2      // Windows 11 September 2022 update
+    Win11_22H2,     // Windows 11 September 2022 update
+    Win11_23H2,     // Windows 11 October 2023 update
+    Win11_24H2      // Windows 11 October 2024 update
 };
 
 struct WinVersion
@@ -113,7 +117,11 @@ BLACKBONE_API inline void InitVersion()
         switch (fullver)
         {
         case _WIN32_WINNT_WIN10:
-            if (g_WinVer.native.dwBuildNumber >= Build_22H2)
+            if (g_WinVer.native.dwBuildNumber >= Build_24H2)
+                g_WinVer.ver = Win11_24H2;
+            else if (g_WinVer.native.dwBuildNumber >= Build_23H2)
+                g_WinVer.ver = Win11_23H2;
+            else if (g_WinVer.native.dwBuildNumber >= Build_22H2)
                 g_WinVer.ver = Win11_22H2;
             else if (g_WinVer.native.dwBuildNumber >= Build_21H2)
                 g_WinVer.ver = Win11_21H2;
@@ -321,6 +329,18 @@ VERSIONHELPERAPI
 IsWindows1122H2OrGreater()
 {
     return IsWindowsVersionOrGreater( HIBYTE( _WIN32_WINNT_WIN10 ), LOBYTE( _WIN32_WINNT_WIN10 ), 0, Build_22H2 );
+}
+
+VERSIONHELPERAPI
+IsWindows1123H2OrGreater()
+{
+    return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0, Build_23H2);
+}
+
+VERSIONHELPERAPI
+IsWindows1124H2OrGreater()
+{
+    return IsWindowsVersionOrGreater(HIBYTE(_WIN32_WINNT_WIN10), LOBYTE(_WIN32_WINNT_WIN10), 0, Build_24H2);
 }
 
 VERSIONHELPERAPI

--- a/src/BlackBone/Symbols/PatternLoader.cpp
+++ b/src/BlackBone/Symbols/PatternLoader.cpp
@@ -77,7 +77,7 @@ void OSFillPatterns( std::unordered_map<ptr_t*, OffsetData>& patterns, SymbolDat
         patterns.emplace(&result.RtlInsertInvertedFunctionTable64, OffsetData{ "\x48\x8B\xC4\x48\x89\x58\x08\x48\x89\x68\x10\x48\x89\x70\x20\x57\x48\x83\xEC\x30\x83\x60\x18\x00", true, 0 });
 
         // RtlpInsertInvertedFunctionTableEntry64
-        patterns.emplace(&result.LdrpInvertedFunctionTable64, OffsetData{ "\x48\x89\x6C\x24\x18\x48\x89\x74\x24\x20\x57\x48\x83\xEC\x20\x8B\x0D\x7B\x5E\x0F\x00", true, 0 });
+        patterns.emplace(&result.LdrpInvertedFunctionTable64, OffsetData{ "\x8B\x0D\xAB\x61\x0F\x00", true, -1, -0xF, 2, 6 });
 
         // RtlInsertInvertedFunctionTable32
         patterns.emplace(&result.RtlInsertInvertedFunctionTable32, OffsetData{ "\x8B\xFF\x55\x8B\xEC\x83\xEC\x0C\x53\x56\x57\x8D\x45\xF8\x8B\xFA", false, 0 });

--- a/src/BlackBone/Symbols/PatternLoader.cpp
+++ b/src/BlackBone/Symbols/PatternLoader.cpp
@@ -69,7 +69,55 @@ void FindPattern( const ScanParams& scan32, const ScanParams& scan64, const Offs
 /// <param name="result">Result</param>
 void OSFillPatterns( std::unordered_map<ptr_t*, OffsetData>& patterns, SymbolData& result )
 {
-    if (IsWindows1121H2OrGreater())
+    if (IsWindows1124H2OrGreater()) {
+        // LdrpHandleTlsData64
+		patterns.emplace(&result.LdrpHandleTlsData64, OffsetData{ "\x4C\x8B\xDC\x49\x89\x5B\x10\x49\x89\x73\x18\x57\x41\x54\x41\x55\x41\x56\x41\x57\x48\x81\xEC\x00\x01\x00\x00", true, 0 });
+
+        // RtlInsertInvertedFunctionTable64
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable64, OffsetData{ "\x48\x8B\xC4\x48\x89\x58\x08\x48\x89\x68\x10\x48\x89\x70\x20\x57\x48\x83\xEC\x30\x83\x60\x18\x00", true, 0 });
+
+        // RtlpInsertInvertedFunctionTableEntry64
+        patterns.emplace(&result.LdrpInvertedFunctionTable64, OffsetData{ "\x48\x89\x6C\x24\x18\x48\x89\x74\x24\x20\x57\x48\x83\xEC\x20\x8B\x0D\x7B\x5E\x0F\x00", true, 0 });
+
+        // RtlInsertInvertedFunctionTable32
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable32, OffsetData{ "\x8B\xFF\x55\x8B\xEC\x83\xEC\x0C\x53\x56\x57\x8D\x45\xF8\x8B\xFA", false, 0 });
+
+        // RtlpInsertInvertedFunctionTableEntry32 - look for  "mov     eax, ds:_LdrpInvertedFunctionTables"
+        // 33 F6 46 3B C6
+        patterns.emplace(&result.LdrpInvertedFunctionTable32, OffsetData{ "\x33\xF6\x46\x3B\xC6", false, -1, -0x1B });
+
+        // LdrpHandleTlsData32
+        patterns.emplace(&result.LdrpHandleTlsData32, OffsetData{ "\x8B\x4D\xB8\x33\xD2", false, 0x42 });
+
+        // LdrProtectMrdata
+        // 75 20 85 f6 75 35
+        patterns.emplace(&result.LdrProtectMrdata, OffsetData{ "\x75\x20\x85\xf6\x75\x35", false, 0x1d });
+    }
+    else if (IsWindows1123H2OrGreater()) {
+		// LdrpHandleTlsData64
+        patterns.emplace(&result.LdrpHandleTlsData64, OffsetData{ "\x48\x89\x5C\x24\x10\x48\x89\x74\x24\x18\x48\x89\x7C\x24\x20\x41\x55", true, 0 });
+
+        // RtlInsertInvertedFunctionTable64
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable64, OffsetData{ "\x48\x89\x5C\x24\x08\x57\x48\x83\xEC\x30\x8B\xDA", true, 0 });
+
+        // RtlpInsertInvertedFunctionTableEntry64
+        patterns.emplace(&result.LdrpInvertedFunctionTable64, OffsetData{ "\x48\x8B\xC4\x48\x89\x58\x08\x48\x89\x68\x10\x48\x89\x70\x18\x48\x89\x78\x20\x41\x56\x48\x83\xEC\x20\x8B\x05\x2D\xF3\x16\x00", true, 0 });
+
+        // RtlInsertInvertedFunctionTable32
+        patterns.emplace(&result.RtlInsertInvertedFunctionTable32, OffsetData{ "\x83\xEC\x0C\x53\x56\x57\x8D\x45\xF8\x8B\xFA", false, 0 });
+
+        // RtlpInsertInvertedFunctionTableEntry32 - look for  "mov     eax, ds:_LdrpInvertedFunctionTables"
+        // 33 F6 46 3B C6
+        patterns.emplace(&result.LdrpInvertedFunctionTable32, OffsetData{ "\x33\xF6\x46\x3B\xC6", false, -1, -0x1B });
+
+        // LdrpHandleTlsData32
+        patterns.emplace(&result.LdrpHandleTlsData32, OffsetData{ "\x33\xF6\x85\xC0\x79\x03", false, 0x42 });
+
+        // LdrProtectMrdata
+        // 75 20 85 f6 75 35
+        patterns.emplace(&result.LdrProtectMrdata, OffsetData{ "\x75\x20\x85\xf6\x75\x35", false, 0x1d });
+    }
+    else if (IsWindows1121H2OrGreater())
     {
         // LdrpHandleTlsData64
         // 41 55 41 56 41 57 48 81 EC F0 00 00


### PR DESCRIPTION
Patterns are from 10th October 2024.
Tested on both versions 23H2 (22631.4249) and 24H2 (26000.2033).

Kind regards
Dominik